### PR TITLE
Contact detector refactoring

### DIFF
--- a/resources/multiverse_episodes/icub_montessori_no_hands/models/iCub.urdf
+++ b/resources/multiverse_episodes/icub_montessori_no_hands/models/iCub.urdf
@@ -36,7 +36,7 @@
     <visual name="SM_root_link_visual_0">
       <origin xyz="0.0 0.0 0.3138580024242401" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_root_link_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_root_link_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_root_link_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -59,7 +59,7 @@
     <visual name="SM_r_hip_1_visual_0">
       <origin xyz="-0.02160000056028366 0.040550000965595245 0.3138580024242401" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_r_hip_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_r_hip_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_hip_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -82,7 +82,7 @@
     <visual name="SM_r_hip_2_visual_0">
       <origin xyz="0.025699999183416367 0.07365000247955322 0.3228580057621002" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_r_hip_2_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_r_hip_2_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_hip_2_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -103,7 +103,7 @@
     <visual name="SM_r_hip_3_visual_0">
       <origin xyz="-0.010999999940395355 0.07365000247955322 0.412557989358902" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_r_hip_3_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_r_hip_3_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_hip_3_visual_0_material">
         <color rgba="0.3 0.3 0.3 1.0"/>
@@ -126,7 +126,7 @@
     <visual name="SM_r_upper_leg_visual_0">
       <origin xyz="-0.010999999940395355 0.058649998158216476 0.483458012342453" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_r_upper_leg_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_r_upper_leg_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_upper_leg_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -149,7 +149,7 @@
     <visual name="SM_r_lower_leg_visual_0">
       <origin xyz="-0.026000000536441803 0.08354999870061874 0.5896580219268799" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_r_lower_leg_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_r_lower_leg_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_lower_leg_visual_0_material">
         <color rgba="0.3 0.3 0.3 1.0"/>
@@ -172,7 +172,7 @@
     <visual name="SM_r_ankle_1_visual_0">
       <origin xyz="-0.026000000536441803 0.08304999768733978 0.8456469774246216" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_r_ankle_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_r_ankle_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_ankle_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -195,7 +195,7 @@
     <visual name="SM_r_ankle_2_visual_0">
       <origin xyz="0.026750000193715096 0.06485000252723694 0.8806470036506653" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_r_ankle_2_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_r_ankle_2_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_ankle_2_visual_0_material">
         <color rgba="0.3 0.3 0.3 1.0"/>
@@ -216,7 +216,7 @@
     <visual name="SM_r_foot_rear_visual_0">
       <origin xyz="0.01075000036507845 0.06485000252723694 0.9464470148086548" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_r_foot_rear_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_r_foot_rear_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_foot_rear_visual_0_material">
         <color rgba="1.0 0.51 0.0 1.0"/>
@@ -249,7 +249,7 @@
     <visual name="SM_r_foot_front_visual_0">
       <origin xyz="-0.10849999636411667 0.06485000252723694 0.9464470148086548" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_r_foot_front_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_r_foot_front_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_foot_front_visual_0_material">
         <color rgba="1.0 0.51 0.0 1.0"/>
@@ -272,7 +272,7 @@
     <visual name="SM_l_hip_1_visual_0">
       <origin xyz="-0.02160000056028366 -0.040449999272823334 0.3138580024242401" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_l_hip_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_l_hip_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_l_hip_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -295,7 +295,7 @@
     <visual name="SM_l_hip_2_visual_0">
       <origin xyz="0.02565000019967556 -0.07355000078678131 0.3228580057621002" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_l_hip_2_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_l_hip_2_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_l_hip_2_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -316,7 +316,7 @@
     <visual name="SM_l_hip_3_visual_0">
       <origin xyz="-0.011049999855458736 -0.07355000078678131 0.412557989358902" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_l_hip_3_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_l_hip_3_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_l_hip_3_visual_0_material">
         <color rgba="0.3 0.3 0.3 1.0"/>
@@ -339,7 +339,7 @@
     <visual name="SM_l_upper_leg_visual_0">
       <origin xyz="-0.011049999855458736 -0.05855000019073486 0.483458012342453" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_l_upper_leg_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_l_upper_leg_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_l_upper_leg_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -362,7 +362,7 @@
     <visual name="SM_l_lower_leg_visual_0">
       <origin xyz="-0.02604999952018261 -0.08344999700784683 0.5896580219268799" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_l_lower_leg_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_l_lower_leg_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_l_lower_leg_visual_0_material">
         <color rgba="0.3 0.3 0.3 1.0"/>
@@ -385,7 +385,7 @@
     <visual name="SM_l_ankle_1_visual_0">
       <origin xyz="-0.02604999952018261 -0.08295000344514847 0.8456469774246216" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_l_ankle_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_l_ankle_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_l_ankle_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -408,7 +408,7 @@
     <visual name="SM_l_ankle_2_visual_0">
       <origin xyz="0.02669999934732914 -0.06475000083446503 0.8806470036506653" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_l_ankle_2_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_l_ankle_2_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_l_ankle_2_visual_0_material">
         <color rgba="0.3 0.3 0.3 1.0"/>
@@ -429,7 +429,7 @@
     <visual name="SM_l_foot_front_visual_0">
       <origin xyz="-0.10854999721050262 -0.06475000083446503 0.9464470148086548" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_l_foot_front_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_l_foot_front_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_l_foot_front_visual_0_material">
         <color rgba="1.0 0.51 0.0 1.0"/>
@@ -450,7 +450,7 @@
     <visual name="SM_l_foot_rear_visual_0">
       <origin xyz="0.010700000450015068 -0.06475000083446503 0.9464470148086548" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_l_foot_rear_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_l_foot_rear_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_l_foot_rear_visual_0_material">
         <color rgba="1.0 0.51 0.0 1.0"/>
@@ -485,7 +485,7 @@
     <visual name="SM_torso_1_visual_0">
       <origin xyz="0.0 0.0 0.25335800647735596" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_torso_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_torso_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_torso_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -508,7 +508,7 @@
     <visual name="SM_torso_2_visual_0">
       <origin xyz="0.0 0.0 0.18085800111293793" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_torso_2_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_torso_2_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_torso_2_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -531,7 +531,7 @@
     <visual name="SM_chest_visual_0">
       <origin xyz="0.0 0.0 0.1163880005478859" rpy="0.0 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_chest_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_chest_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_chest_visual_0_material">
         <color rgba="0.3 0.3 0.3 1.0"/>
@@ -576,7 +576,7 @@
     <visual name="SM_neck_1_visual_0">
       <origin xyz="0.00865000020712614 0.0 0.04899999871850014" rpy="-1.5707963705062866 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_head_neck_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_head_neck_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_neck_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -599,7 +599,7 @@
     <visual name="SM_neck_2_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="-1.5707963705062866 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_head_neck_2_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_head_neck_2_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_neck_2_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -622,7 +622,7 @@
     <visual name="SM_neck_3_visual_0">
       <origin xyz="0.0 0.0 -0.009500499814748764" rpy="-1.5707963705062866 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_head_neck_3_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_head_neck_3_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_neck_3_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -645,7 +645,7 @@
     <visual name="SM_head_visual_0">
       <origin xyz="0.0 0.0 -0.07865049690008163" rpy="-1.5707963705062866 0.0 -1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_head_head_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_head_head_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_head_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -758,7 +758,7 @@
     <visual name="SM_r_shoulder_1_visual_0">
       <origin xyz="0.030411234125494957 0.02914046309888363 0.019095774739980698" rpy="-0.0668872520327568 0.244452565908432 -1.8408154249191284"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_r_shoulder_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_r_shoulder_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_shoulder_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -781,7 +781,7 @@
     <visual name="SM_r_shoulder_2_visual_0">
       <origin xyz="0.023893259465694427 0.14064089953899384 0.017434528097510338" rpy="-0.12008540332317352 0.2297886610031128 -1.8533143997192383"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_r_shoulder_2_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_r_shoulder_2_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_shoulder_2_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -802,7 +802,7 @@
     <visual name="SM_r_shoulder_3_visual_0">
       <origin xyz="0.030743205919861794 0.14064067602157593 0.07173451036214828" rpy="-0.12008540332317352 0.2297886610031128 -1.8533143997192383"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_r_shoulder_3_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_r_shoulder_3_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_shoulder_3_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -825,7 +825,7 @@
     <visual name="SM_r_upper_arm_visual_0">
       <origin xyz="0.030743123963475227 0.1406402587890625 0.09423445165157318" rpy="-0.12008540332317352 0.2297886610031128 -1.8533143997192383"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_r_upperarm_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_r_upperarm_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_upper_arm_visual_0_material">
         <color rgba="0.3 0.3 0.3 1.0"/>
@@ -848,7 +848,7 @@
     <visual name="SM_r_elbow_1_visual_0">
       <origin xyz="0.020743191242218018 0.13914062082767487 0.21793478727340698" rpy="-0.12008540332317352 0.2297886610031128 -1.8533143997192383"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_r_elbow_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_r_elbow_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_elbow_1_visual_0_material">
         <color rgba="0.3 0.3 0.3 1.0"/>
@@ -871,7 +871,7 @@
     <visual name="SM_r_forearm_visual_0">
       <origin xyz="0.03574306145310402 0.14114026725292206 0.27323484420776367" rpy="-0.12008540332317352 0.2297886610031128 -1.8533143997192383"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_r_forearm_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_r_forearm_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_forearm_visual_0_material">
         <color rgba="0.3 0.3 0.3 1.0"/>
@@ -894,7 +894,7 @@
     <visual name="SM_r_wrist_1_visual_0">
       <origin xyz="0.019443107768893242 0.14314770698547363 0.380734920501709" rpy="-0.12008540332317352 0.2297886610031128 -1.8533143997192383"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_r_wrist_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_r_wrist_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_wrist_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -917,7 +917,7 @@
     <visual name="SM_r_hand_visual_0">
       <origin xyz="0.0027160674799233675 -0.0015567999798804522 -0.0024823539424687624" rpy="-1.5707963705062866 0.26179930567741394 2.069615773247005e-13"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightHandPalm.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightHandPalm.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -926,7 +926,7 @@
     <visual name="SM_r_hand_visual_1">
       <origin xyz="-0.05765429884195328 -0.005556799937039614 0.013693831861019135" rpy="-1.5707963705062866 -0.26179930567741394 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightTopCover.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightTopCover.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_r_hand_visual_1_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -949,7 +949,7 @@
     <visual name="SM_r_hand_thumb_0_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 3.1415927410125732 1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightThumb0.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightThumb0.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_thumb_0_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -972,7 +972,7 @@
     <visual name="SM_r_hand_thumb_1_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 0.0"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightThumb1.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightThumb1.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_thumb_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -995,7 +995,7 @@
     <visual name="SM_r_hand_thumb_2_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 0.0"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightThumb2.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightThumb2.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_thumb_2_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1018,7 +1018,7 @@
     <visual name="SM_r_hand_thumb_3_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightThumb3.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightThumb3.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_thumb_3_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1053,7 +1053,7 @@
     <visual name="SM_r_hand_index_0_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightIndex0.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightIndex0.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_index_0_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1076,7 +1076,7 @@
     <visual name="SM_r_hand_index_1_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 0.0"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightIndex1.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightIndex1.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_index_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1099,7 +1099,7 @@
     <visual name="SM_r_hand_index_2_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 0.0"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightIndex2.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightIndex2.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_index_2_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1122,7 +1122,7 @@
     <visual name="SM_r_hand_index_3_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightIndex3.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightIndex3.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_index_3_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1157,7 +1157,7 @@
     <visual name="SM_r_hand_middle_0_visual_0">
       <origin xyz="0.0 0.0 0.0035000001080334187" rpy="0.0 0.0 0.0"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightMiddle0.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightMiddle0.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_middle_0_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1180,7 +1180,7 @@
     <visual name="SM_r_hand_middle_1_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 0.0"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightMiddle1.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightMiddle1.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_middle_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1203,7 +1203,7 @@
     <visual name="SM_r_hand_middle_2_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightMiddle2.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightMiddle2.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_middle_2_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1226,7 +1226,7 @@
     <visual name="SM_r_hand_middle_3_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightMiddle3.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightMiddle3.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_middle_3_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1261,7 +1261,7 @@
     <visual name="SM_r_hand_ring_0_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightRing0.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightRing0.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_ring_0_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1284,7 +1284,7 @@
     <visual name="SM_r_hand_ring_1_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightRing1.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightRing1.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_ring_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1307,7 +1307,7 @@
     <visual name="SM_r_hand_ring_2_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 0.0"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightRing2.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightRing2.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_ring_2_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1330,7 +1330,7 @@
     <visual name="SM_r_hand_ring_3_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightRing3.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightRing3.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_ring_3_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1365,7 +1365,7 @@
     <visual name="SM_r_hand_little_0_visual_0">
       <origin xyz="0.0 0.0 0.003800000064074993" rpy="0.0 0.0 0.0"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightLittle0.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightLittle0.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_little_0_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1388,7 +1388,7 @@
     <visual name="SM_r_hand_little_1_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 0.0"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightLittle1.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightLittle1.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_little_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1411,7 +1411,7 @@
     <visual name="SM_r_hand_little_2_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 0.0"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightLittle2.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightLittle2.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_little_2_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1434,7 +1434,7 @@
     <visual name="SM_r_hand_little_3_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_RightLittle3.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_RightLittle3.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_r_hand_little_3_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1481,7 +1481,7 @@
     <visual name="SM_l_shoulder_1_visual_0">
       <origin xyz="0.03041122294962406 -0.029140478000044823 0.0190957672894001" rpy="-0.06688748300075531 -0.24445247650146484 -1.3007776737213135"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_l_shoulder_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_l_shoulder_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_l_shoulder_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1504,7 +1504,7 @@
     <visual name="SM_l_shoulder_2_visual_0">
       <origin xyz="0.026393096894025803 -0.14064030349254608 0.017434481531381607" rpy="-0.12008543312549591 -0.22978873550891876 -1.2882781028747559"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_l_shoulder_2_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_l_shoulder_2_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_l_shoulder_2_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1525,7 +1525,7 @@
     <visual name="SM_l_shoulder_3_visual_0">
       <origin xyz="0.030743230134248734 -0.14064067602157593 0.07173451781272888" rpy="-0.12008543312549591 -0.22978873550891876 -1.2882781028747559"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_l_shoulder_3_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_l_shoulder_3_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_l_shoulder_3_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1548,7 +1548,7 @@
     <visual name="SM_l_upper_arm_visual_0">
       <origin xyz="0.030743148177862167 -0.1406402438879013 0.09423445910215378" rpy="-0.12008543312549591 -0.22978873550891876 -1.2882781028747559"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_l_upperarm_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_l_upperarm_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_l_upper_arm_visual_0_material">
         <color rgba="0.3 0.3 0.3 1.0"/>
@@ -1571,7 +1571,7 @@
     <visual name="SM_l_elbow_1_visual_0">
       <origin xyz="0.020743217319250107 -0.13914059102535248 0.21793480217456818" rpy="-0.12008543312549591 -0.22978873550891876 -1.2882781028747559"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_l_elbow_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_l_elbow_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_l_elbow_1_visual_0_material">
         <color rgba="0.3 0.3 0.3 1.0"/>
@@ -1594,7 +1594,7 @@
     <visual name="SM_l_forearm_visual_0">
       <origin xyz="0.03574308753013611 -0.14114023745059967 0.27323487401008606" rpy="-0.12008543312549591 -0.22978873550891876 -1.2882781028747559"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_l_forearm_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_l_forearm_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_l_forearm_visual_0_material">
         <color rgba="0.3 0.3 0.3 1.0"/>
@@ -1617,7 +1617,7 @@
     <visual name="SM_l_wrist_1_visual_0">
       <origin xyz="0.01914307288825512 -0.14314714074134827 0.38073450326919556" rpy="-0.12008543312549591 -0.22978873550891876 -1.2882781028747559"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/sim_icub3_l_wrist_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/sim_icub3_l_wrist_1_prt.stl" scale="0.0010000000474974513 0.0010000000474974513 0.0010000000474974513"/>
       </geometry>
       <material name="SM_l_wrist_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1640,7 +1640,7 @@
     <visual name="SM_l_hand_visual_0">
       <origin xyz="-0.0027160674799233675 -0.0015567999798804522 -0.0024823539424687624" rpy="1.5707963705062866 -0.26179930567741394 3.3224480235523256e-17"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftHandPalm.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftHandPalm.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1649,7 +1649,7 @@
     <visual name="SM_l_hand_visual_1">
       <origin xyz="0.05765429884195328 -0.005556799937039614 0.013693831861019135" rpy="-1.5707963705062866 -0.26179930567741394 5.746937229130156e-17"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftTopCover.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftTopCover.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_visual_1_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1684,7 +1684,7 @@
     <visual name="SM_l_hand_thumb_0_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 0.0"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftThumb0.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftThumb0.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_thumb_0_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1707,7 +1707,7 @@
     <visual name="SM_l_hand_thumb_1_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftThumb1.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftThumb1.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_thumb_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1730,7 +1730,7 @@
     <visual name="SM_l_hand_thumb_2_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftThumb2.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftThumb2.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_thumb_2_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1753,7 +1753,7 @@
     <visual name="SM_l_hand_thumb_3_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 3.1415927410125732 0.0"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftThumb3.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftThumb3.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_thumb_3_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1788,7 +1788,7 @@
     <visual name="SM_l_hand_index_0_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftIndex0.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftIndex0.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_index_0_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1811,7 +1811,7 @@
     <visual name="SM_l_hand_index_1_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftIndex1.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftIndex1.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_index_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1834,7 +1834,7 @@
     <visual name="SM_l_hand_index_2_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftIndex2.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftIndex2.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_index_2_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1857,7 +1857,7 @@
     <visual name="SM_l_hand_index_3_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftIndex3.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftIndex3.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_index_3_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1892,7 +1892,7 @@
     <visual name="SM_l_hand_middle_0_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftMiddle0.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftMiddle0.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_middle_0_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1915,7 +1915,7 @@
     <visual name="SM_l_hand_middle_1_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftMiddle1.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftMiddle1.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_middle_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1938,7 +1938,7 @@
     <visual name="SM_l_hand_middle_2_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftMiddle2.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftMiddle2.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_middle_2_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1961,7 +1961,7 @@
     <visual name="SM_l_hand_middle_3_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftMiddle3.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftMiddle3.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_middle_3_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -1996,7 +1996,7 @@
     <visual name="SM_l_hand_ring_0_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftRing0.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftRing0.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_ring_0_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -2019,7 +2019,7 @@
     <visual name="SM_l_hand_ring_1_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="1.5707963705062866 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftRing1.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftRing1.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_ring_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -2042,7 +2042,7 @@
     <visual name="SM_l_hand_ring_2_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftRing2.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftRing2.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_ring_2_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -2065,7 +2065,7 @@
     <visual name="SM_l_hand_ring_3_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftRing3.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftRing3.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_ring_3_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -2100,7 +2100,7 @@
     <visual name="SM_l_hand_little_0_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="-3.1415927410125732 -1.5707963705062866 1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftLittle0.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftLittle0.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_little_0_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -2123,7 +2123,7 @@
     <visual name="SM_l_hand_little_1_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 3.1415927410125732 1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftLittle1.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftLittle1.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_little_1_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -2146,7 +2146,7 @@
     <visual name="SM_l_hand_little_2_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftLittle2.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftLittle2.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_little_2_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>
@@ -2169,7 +2169,7 @@
     <visual name="SM_l_hand_little_3_visual_0">
       <origin xyz="0.0 0.0 0.0" rpy="3.1415927410125732 0.0 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://iCub/meshes/stl/full_LeftLittle3.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/iCub/meshes/stl/full_LeftLittle3.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="SM_l_hand_little_3_visual_0_material">
         <color rgba="0.9 0.9 0.9 1.0"/>

--- a/resources/multiverse_episodes/icub_montessori_no_hands/models/montessori_object_2.urdf
+++ b/resources/multiverse_episodes/icub_montessori_no_hands/models/montessori_object_2.urdf
@@ -9,7 +9,7 @@
     <collision name="MontessoriObject2">
       <origin xyz="-0.005819993559271097 1.2720914664890083e-19 3.725290298461914e-09" rpy="0.0 0.0 0.0"/>
       <geometry>
-        <mesh filename="file://montessori_object_1/meshes/stl/montessori_object_2_MontessoriObject_002.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/resources/multiverse_episodes/icub_montessori_no_hands/models/scene/meshes/stl/montessori_object_2_MontessoriObject_002.stl" scale="1.0 1.0 1.0"/>
       </geometry>
     </collision>
   </link>

--- a/resources/multiverse_episodes/icub_montessori_no_hands/models/scene.urdf
+++ b/resources/multiverse_episodes/icub_montessori_no_hands/models/scene.urdf
@@ -267,7 +267,7 @@
     <visual name="MontessoriBox">
       <origin xyz="0.00525750732049346 1.4678077604912687e-05 -0.0003088224621023983" rpy="-1.586214303970337 -1.5560582876205444 -3.1267335414886475"/>
       <geometry>
-        <mesh filename="file://scene/meshes/stl/montessori_box_MontessoriBox.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/resources/multiverse_episodes/icub_montessori_no_hands/models/scene/meshes/stl/montessori_box_MontessoriBox.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="MontessoriBox_material">
         <color rgba="0.89 0.67 0.57 1.0"/>
@@ -330,7 +330,7 @@
     <collision name="MontessoriObject2">
       <origin xyz="-0.005819993559271097 1.2720914664890083e-19 3.725290298461914e-09" rpy="0.0 0.0 0.0"/>
       <geometry>
-        <mesh filename="file://montessori_object_1/meshes/stl/montessori_object_2_MontessoriObject_002.stl" scale="0.8 0.8 0.02"/>
+        <mesh filename="/home/sorin/dev/Segmind/resources/multiverse_episodes/icub_montessori_no_hands/models/scene/meshes/stl/montessori_object_2_MontessoriObject_002.stl" scale="0.8 0.8 0.02"/>
       </geometry>
     </collision>
   </link>
@@ -437,7 +437,7 @@
     <visual name="MontessoriDrawer1">
       <origin xyz="0.00039275470771826804 -9.528518252199802e-11 -0.004749107174575329" rpy="0.0 -1.5696903467178345 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://scene/meshes/stl/montessori_box_MontessoriDrawer.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/resources/multiverse_episodes/icub_montessori_no_hands/models/scene/meshes/stl/montessori_box_MontessoriDrawer.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="MontessoriDrawer1_material">
         <color rgba="1.0 0.83 0.67 1.0"/>
@@ -470,7 +470,7 @@
     <visual name="MontessoriDrawer1Handle">
       <origin xyz="0.0039155809208750725 7.543388136355134e-09 -2.279017252693194e-11" rpy="1.5707963705062866 -1.3322676295501878e-15 1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://scene/meshes/stl/montessori_box_MontessoriDrawerHandle.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/resources/multiverse_episodes/icub_montessori_no_hands/models/scene/meshes/stl/montessori_box_MontessoriDrawerHandle.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="MontessoriDrawer1Handle_material">
         <color rgba="0.89 0.67 0.57 1.0"/>
@@ -523,7 +523,7 @@
     <visual name="MontessoriDrawer2">
       <origin xyz="0.00039275470771826804 -9.528518252199802e-11 -0.004749107174575329" rpy="0.0 -1.5696903467178345 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://scene/meshes/stl/montessori_box_MontessoriDrawer.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/resources/multiverse_episodes/icub_montessori_no_hands/models/scene/meshes/stl/montessori_box_MontessoriDrawer.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="MontessoriDrawer2_material">
         <color rgba="0.99 0.73 0.55 1.0"/>
@@ -556,7 +556,7 @@
     <visual name="MontessoriDrawer2Handle">
       <origin xyz="0.0039155809208750725 7.543388136355134e-09 -2.279017252693194e-11" rpy="1.5707963705062866 -1.3322676295501878e-15 1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://scene/meshes/stl/montessori_box_MontessoriDrawerHandle.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/resources/multiverse_episodes/icub_montessori_no_hands/models/scene/meshes/stl/montessori_box_MontessoriDrawerHandle.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="MontessoriDrawer2Handle_material">
         <color rgba="0.89 0.67 0.57 1.0"/>
@@ -609,7 +609,7 @@
     <visual name="MontessoriDrawer3">
       <origin xyz="0.00039275470771826804 -9.528518252199802e-11 -0.004749107174575329" rpy="0.0 -1.5696903467178345 3.1415927410125732"/>
       <geometry>
-        <mesh filename="file://scene/meshes/stl/montessori_box_MontessoriDrawer.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/resources/multiverse_episodes/icub_montessori_no_hands/models/scene/meshes/stl/montessori_box_MontessoriDrawer.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="MontessoriDrawer3_material">
         <color rgba="0.87 0.94 0.98 1.0"/>
@@ -642,7 +642,7 @@
     <visual name="MontessoriDrawer3Handle">
       <origin xyz="0.0039155809208750725 7.543388136355134e-09 -2.279017252693194e-11" rpy="1.5707963705062866 -1.3322676295501878e-15 1.5707963705062866"/>
       <geometry>
-        <mesh filename="file://scene/meshes/stl/montessori_box_MontessoriDrawerHandle.stl" scale="1.0 1.0 1.0"/>
+        <mesh filename="/home/sorin/dev/Segmind/resources/multiverse_episodes/icub_montessori_no_hands/models/scene/meshes/stl/montessori_box_MontessoriDrawerHandle.stl" scale="1.0 1.0 1.0"/>
       </geometry>
       <material name="MontessoriDrawer3Handle_material">
         <color rgba="0.89 0.67 0.57 1.0"/>

--- a/src/segmind/__init__.py
+++ b/src/segmind/__init__.py
@@ -1,1 +1,46 @@
 __version__ = "1.0.32"
+import logging
+from colorlog import ColoredFormatter
+
+from enum import Enum
+
+logger = logging.Logger("segmind")
+logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
+
+# Handler
+handler = logging.StreamHandler()
+formatter = ColoredFormatter(
+    "%(log_color)s%(asctime)s %(name)s %(levelname)s: %(message)s",
+    datefmt=None,
+    log_colors={
+        "DEBUG": "blue",
+        "INFO": "reset",
+        "WARNING": "yellow",
+        "ERROR": "red",
+        "CRITICAL": "bold_red",
+    }
+)
+handler.setFormatter(formatter)
+handler.setLevel(logging.INFO)  # <-- this filters out DEBUG messages
+logger.addHandler(handler)
+
+
+class LogLevel(Enum):
+    """
+    Just to give a type to logging levels for type hints.
+    """
+
+    DEBUG = logging.DEBUG
+    INFO = logging.INFO
+    WARNING = logging.WARNING
+    ERROR = logging.ERROR
+    CRITICAL = logging.CRITICAL
+
+
+def set_logger_level(level: LogLevel):
+    """
+    Because logging levels are filtered by the handler, we need to set the level of the handler. While
+    we keep the logger level at DEBUG to allow all messages to pass through.
+    """
+    handler.setLevel(level.value)

--- a/src/segmind/datastructures/events.py
+++ b/src/segmind/datastructures/events.py
@@ -2,21 +2,20 @@ import time
 from abc import abstractmethod, ABC
 from dataclasses import dataclass, field
 
-from pycram.datastructures.dataclasses import Color
+from krrood.ormatic.dao import to_dao
 from pycram.datastructures.enums import Arms
 from pycram.datastructures.partial_designator import PartialDesignator
-from pycram.datastructures.pose import PoseStamped
-from pycram.robot_plans import ActionDescription, PlaceAction, PickUpAction, PlaceActionDescription, \
-    PickUpActionDescription
-from semantic_digital_twin.collision_checking.collision_detector import Collision
-from semantic_digital_twin.collision_checking.trimesh_collision_detector import TrimeshCollisionDetector
-from semantic_digital_twin.spatial_types.spatial_types import Pose
-from semantic_digital_twin.world_description.geometry import BoundingBox
-from semantic_digital_twin.world_description.world_entity import Body, Agent
 from typing_extensions import Optional, List, Union, Type
 
+from pycram.datastructures.pose import PoseStamped
+from pycram.robot_plans import PlaceActionDescription, PlaceAction, ActionDescription, PickUpActionDescription, \
+    PickUpAction
 from segmind.datastructures.mixins import HasPrimaryTrackedObject, HasPrimaryAndSecondaryTrackedObjects
 from segmind.datastructures.object_tracker import ObjectTrackerFactory
+from semantic_digital_twin.orm.ormatic_interface import BodyDAO
+from semantic_digital_twin.spatial_types.spatial_types import Pose
+from semantic_digital_twin.world_description.geometry import Color, BoundingBox
+from semantic_digital_twin.world_description.world_entity import Body, Agent
 
 
 @dataclass
@@ -263,25 +262,25 @@ class StopRotationEvent(StopMotionEvent):
 
 @dataclass(init=False, unsafe_hash=True)
 class AbstractContactEvent(EventWithTwoTrackedObjects, ABC):
-    contact_points: list[Collision] = field(init=False, default_factory=list)
-    latest_contact_points: list[Collision] = field(init=False, default_factory=list)
+    contact_bodies: list[Body] = field(init=False, default_factory=list[Body])
+    latest_contact_bodies: list[Body] = field(init=False, default_factory=list[Body])
     bounding_box: BoundingBox = field(init=False)
     pose: PoseStamped = field(init=False)
     with_object_bounding_box: Optional[BoundingBox] = field(init=False, default=None)
     with_object_pose: Optional[PoseStamped] = field(init=False, default=None)
 
     def __init__(self,
-                 contact_points: list[Collision],
+                 contact_bodies: list[Body],
                  of_object: Body,
-                 latest_contact_points: Optional[list[Collision]] = None,
+                 latest_contact_bodies: Optional[list[Body]] = None,
                  with_object: Optional[Body] = None,
                  timestamp: Optional[float] = None):
         EventWithTwoTrackedObjects.__init__(self,
                                             tracked_object=of_object,
                                             with_object=with_object,
                                             timestamp=timestamp if timestamp is not None else time.time())
-        self.contact_points: list[Collision] = contact_points
-        self.latest_contact_points: list[Collision] = latest_contact_points if latest_contact_points is not None else []
+        self.contact_bodies: list[Body] = contact_bodies
+        self.latest_contact_bodies: list[Body] = latest_contact_bodies
         self.bounding_box: BoundingBox = BoundingBox.from_mesh(
             of_object.collision.combined_mesh,
             origin=of_object.global_pose
@@ -338,20 +337,18 @@ class ContactEvent(AbstractContactEvent):
 
     @property
     def objects(self):
-        from segmind.detectors.atomic_event_detectors import AbstractContactDetector
-        return AbstractContactDetector.get_bodies_in_contact(self.contact_points)
+        return self.contact_bodies
 
     @property
     def main_link(self):
-        if len(self.contact_points) > 0:
-            return self.contact_points[0].body_a
+        if len(self.contact_bodies) > 0:
+            return self.contact_bodies[0].name
         else:
             print(f"No contact points found for {self.tracked_object.name} in {self.__class__.__name__}")
 
     @property
     def links(self):
-        from segmind.detectors.atomic_event_detectors import AbstractContactDetector
-        return AbstractContactDetector.get_bodies_in_contact(self.contact_points)
+        return self.contact_bodies
 
 
 @dataclass(init=False, unsafe_hash=True)
@@ -364,31 +361,19 @@ class LossOfContactEvent(AbstractContactEvent):
 
     @property
     def latest_objects_that_got_removed(self):
-        prev_contacts = {
-            (cp.body_a, cp.body_b) for cp in self.latest_contact_points
-        }
-        curr_contacts = {(cp.body_a, cp.body_b) for cp in self.contact_points}
-        lost_contact_pairs = prev_contacts - curr_contacts
-        return list({b for (a, b) in lost_contact_pairs if a == self.tracked_object})
+        return self.get_objects_that_got_removed(self.latest_contact_bodies)
+
+    def get_objects_that_got_removed(self, latest_contact_bodies: list[Body]):
+        objects_that_got_removed: list[Body] = []
+        for obj in latest_contact_bodies:
+            if obj not in self.contact_bodies:
+                objects_that_got_removed.append(obj)
+
+        return objects_that_got_removed
 
     @property
     def color(self) -> Color:
         return Color(1, 0, 0, 1)
-
-    @property
-    def main_link(self) -> Body:
-        if len(self.latest_contact_points) > 0:
-            return self.latest_contact_points[0].body_a
-        return self.tracked_object
-
-    @property
-    def links(self) -> List[Body]:
-        return self.latest_objects_that_got_removed
-
-    @property
-    def objects(self) -> List[Body]:
-        return self.latest_objects_that_got_removed
-
 
 @dataclass(init=False, unsafe_hash=True)
 class LossOfInterferenceEvent(LossOfContactEvent):
@@ -407,7 +392,7 @@ class AbstractAgentContact(AbstractContactEvent, ABC):
 
     def with_object_contact_link(self) -> Optional[Body]:
         if self.with_object is not None:
-            return [link for link in self.links if link.parent_entity == self.with_object][0]
+            return [link for link in self.links if link.parent_connection.parent == self.with_object][0]
         else:
             return None
 
@@ -419,13 +404,12 @@ class AbstractAgentContact(AbstractContactEvent, ABC):
 
 @dataclass(init=False, unsafe_hash=True)
 class AgentContactEvent(ContactEvent, AbstractAgentContact):
-
     @property
     def object_link(self) -> Body:
         if self.with_object is not None:
             return self.with_object_contact_link()
         else:
-            return self.contact_points[0].link_b
+            return self.contact_bodies[0].parent_connection.child
 
 
 @dataclass(init=False, unsafe_hash=True)
@@ -441,7 +425,7 @@ class AgentLossOfContactEvent(LossOfContactEvent, AbstractAgentContact):
         if self.with_object is not None:
             return self.with_object_contact_link()
         else:
-            return self.latest_contact_points[0].link_b
+            return self.latest_contact_bodies[0].parent_connection.child
 
 
 @dataclass(init=False, unsafe_hash=True)
@@ -451,10 +435,10 @@ class AgentLossOfInterferenceEvent(LossOfInterferenceEvent, AgentLossOfContactEv
 
 @dataclass(kw_only=True)
 class AbstractAgentObjectInteractionEvent(EventWithTwoTrackedObjects, ABC):
-    agent: Optional[Body] = None
+    agent: Optional[Agent] = None
     timestamp: Optional[float] = None
     end_timestamp: Optional[float] = None
-    agent_frozen_cp: Optional[Body] = field(init=False, default=None, repr=False, hash=False)
+    agent_frozen_cp: Optional[BodyDAO] = field(init=False, default=None, repr=False, hash=False)
 
     def __post_init__(self):
         EventWithTwoTrackedObjects.__post_init__(self)
@@ -469,7 +453,7 @@ class AbstractAgentObjectInteractionEvent(EventWithTwoTrackedObjects, ABC):
     def agent_state(self) -> Optional[Agent]:
         if self.agent is None:
             return None
-        return self.agent.state
+        return self.agent
 
     def __eq__(self, other):
         if self.end_timestamp is None:
@@ -533,7 +517,7 @@ class PlacingEvent(AbstractAgentObjectInteractionEvent):
 
     def action_description(self, pose: Optional[PoseStamped] = None, arm: Optional[Arms] = None) -> Type[PlaceActionDescription]:
         if pose is None:
-            pose = self.tracked_object.pose
+            pose = self.tracked_object.global_pose.to_pose()
         return PlaceActionDescription(self.tracked_object, pose, arm)
 
     @property
@@ -566,7 +550,7 @@ class InsertionEvent(AbstractAgentObjectInteractionEvent):
         return PlaceAction
 
     def action_description(self) -> Type[PlaceActionDescription]:
-        return PlaceActionDescription(self.tracked_object, self.through_hole.global_pose)
+        return PlaceActionDescription(self.tracked_object, self.through_hole.global_pose.to_pose(), insert=True)
 
     def hash_tuple(self):
         hash_tuple = (*super().hash_tuple, *(obj.name for obj in self.inserted_into_objects))

--- a/src/segmind/datastructures/events.py
+++ b/src/segmind/datastructures/events.py
@@ -3,13 +3,12 @@ from abc import abstractmethod, ABC
 from dataclasses import dataclass, field
 
 from pycram.datastructures.dataclasses import Color
-from pycram.datastructures.enums import Arms
 from pycram.datastructures.partial_designator import PartialDesignator
 from typing_extensions import Optional, List, Union, Type
 
 from pycram.datastructures.pose import PoseStamped
-from pycram.robot_plans import PlaceActionDescription, PlaceAction, ActionDescription, PickUpActionDescription, \
-    PickUpAction
+from pycram.robot_plans import ActionDescription, PickUpActionDescription, PickUpAction, PlaceActionDescription, \
+    PlaceAction
 from segmind.datastructures.mixins import HasPrimaryTrackedObject, HasPrimaryAndSecondaryTrackedObjects
 from segmind.datastructures.object_tracker import ObjectTrackerFactory
 from semantic_digital_twin.orm.ormatic_interface import BodyDAO
@@ -211,15 +210,15 @@ class MotionEvent(EventWithOneTrackedObject, ABC):
     The MotionEvent class is used to represent an event that involves an object that was stationary and then moved or
     vice versa.
     """
-    start_pose: PoseStamped = field(init=False)
-    current_pose: PoseStamped = field(init=False)
+    start_pose: Pose = field(init=False)
+    current_pose: Pose = field(init=False)
 
-    def __init__(self, tracked_object: Body, start_pose: PoseStamped, current_pose: PoseStamped,
+    def __init__(self, tracked_object: Body, start_pose: Pose, current_pose: Pose,
                  timestamp: Optional[float] = None):
         EventWithOneTrackedObject.__init__(self, tracked_object=tracked_object,
                                            timestamp=timestamp if timestamp is not None else time.time())
-        self.start_pose: PoseStamped = start_pose
-        self.current_pose: PoseStamped = current_pose
+        self.start_pose: Pose = start_pose
+        self.current_pose: Pose = current_pose
 
     @property
     def involved_bodies(self) -> List[Body]:
@@ -262,25 +261,25 @@ class StopRotationEvent(StopMotionEvent):
 
 @dataclass(init=False, unsafe_hash=True)
 class AbstractContactEvent(EventWithTwoTrackedObjects, ABC):
-    contact_bodies: list[Body] = field(init=False, default_factory=list[Body])
-    latest_contact_bodies: list[Body] = field(init=False, default_factory=list[Body])
+    close_bodies: list[Body] = field(init=False, default_factory=list[Body])
+    latest_close_bodies: list[Body] = field(init=False, default_factory=list[Body])
     bounding_box: BoundingBox = field(init=False)
     pose: PoseStamped = field(init=False)
     with_object_bounding_box: Optional[BoundingBox] = field(init=False, default=None)
     with_object_pose: Optional[PoseStamped] = field(init=False, default=None)
 
     def __init__(self,
-                 contact_bodies: list[Body],
+                 close_bodies: list[Body],
                  of_object: Body,
-                 latest_contact_bodies: Optional[list[Body]] = None,
+                 latest_close_bodies: Optional[list[Body]] = None,
                  with_object: Optional[Body] = None,
                  timestamp: Optional[float] = None):
         EventWithTwoTrackedObjects.__init__(self,
                                             tracked_object=of_object,
                                             with_object=with_object,
                                             timestamp=timestamp if timestamp is not None else time.time())
-        self.contact_bodies: list[Body] = contact_bodies
-        self.latest_contact_bodies: list[Body] = latest_contact_bodies
+        self.close_bodies: list[Body] = close_bodies
+        self.latest_close_bodies: list[Body] = latest_close_bodies
         self.bounding_box: BoundingBox = BoundingBox.from_mesh(
             of_object.collision.combined_mesh,
             origin=of_object.global_pose
@@ -337,18 +336,18 @@ class ContactEvent(AbstractContactEvent):
 
     @property
     def objects(self):
-        return self.contact_bodies
+        return self.close_bodies.get_objects_that_have_points()
 
     @property
     def main_link(self):
-        if len(self.contact_bodies) > 0:
-            return self.contact_bodies[0].name
+        if len(self.close_bodies) > 0:
+            return self.close_bodies[0].link_a
         else:
             print(f"No contact points found for {self.tracked_object.name} in {self.__class__.__name__}")
 
     @property
     def links(self):
-        return self.contact_bodies
+        return self.close_bodies
 
 
 @dataclass(init=False, unsafe_hash=True)
@@ -361,19 +360,27 @@ class LossOfContactEvent(AbstractContactEvent):
 
     @property
     def latest_objects_that_got_removed(self):
-        return self.get_objects_that_got_removed(self.latest_contact_bodies)
+        return self.get_objects_that_got_removed(self.latest_close_bodies)
 
-    def get_objects_that_got_removed(self, latest_contact_bodies: list[Body]):
-        objects_that_got_removed: list[Body] = []
-        for obj in latest_contact_bodies:
-            if obj not in self.contact_bodies:
-                objects_that_got_removed.append(obj)
-
-        return objects_that_got_removed
+    def get_objects_that_got_removed(self, close_bodies: list[Body]):
+        return self.close_bodies.get_objects_that_got_removed(close_bodies)
 
     @property
     def color(self) -> Color:
         return Color(1, 0, 0, 1)
+
+    @property
+    def main_link(self) -> Body:
+        return self.latest_close_bodies[0]
+
+    @property
+    def links(self) -> List[Body]:
+        return self.close_bodies.get_bodies_that_got_removed(self.latest_close_bodies)
+
+    @property
+    def objects(self):
+        return self.close_bodies.get_objects_that_got_removed(self.close_bodies)
+
 
 @dataclass(init=False, unsafe_hash=True)
 class LossOfInterferenceEvent(LossOfContactEvent):
@@ -404,6 +411,7 @@ class AbstractAgentContact(AbstractContactEvent, ABC):
 
 @dataclass(init=False, unsafe_hash=True)
 class AgentContactEvent(ContactEvent, AbstractAgentContact):
+
     @property
     def object_link(self) -> Body:
         if self.with_object is not None:
@@ -425,7 +433,7 @@ class AgentLossOfContactEvent(LossOfContactEvent, AbstractAgentContact):
         if self.with_object is not None:
             return self.with_object_contact_link()
         else:
-            return self.latest_contact_bodies[0].parent_connection.child
+            return self.latest_close_bodies[0].link_b
 
 
 @dataclass(init=False, unsafe_hash=True)
@@ -499,7 +507,7 @@ class PickUpEvent(AbstractAgentObjectInteractionEvent):
     def color(self) -> Color:
         return Color(0, 1, 0, 1)
 
-    def action_description(self) -> Type[PickUpActionDescription]:
+    def action_description(self) -> PickUpActionDescription:
         return PickUpActionDescription(self.tracked_object)
 
     @property
@@ -515,10 +523,10 @@ class PlacingEvent(AbstractAgentObjectInteractionEvent):
     def color(self) -> Color:
         return Color(1, 0, 1, 1)
 
-    def action_description(self, pose: Optional[PoseStamped] = None, arm: Optional[Arms] = None) -> Type[PlaceActionDescription]:
+    def action_description(self, pose: Optional[PoseStamped] = None) -> PlaceActionDescription:
         if pose is None:
-            pose = self.tracked_object.global_pose.to_pose()
-        return PlaceActionDescription(self.tracked_object, pose, arm)
+            pose = self.tracked_object.pose
+        return PlaceActionDescription(self.tracked_object, pose)
 
     @property
     def action_type(self) -> Type[PlaceAction]:
@@ -528,7 +536,7 @@ class PlacingEvent(AbstractAgentObjectInteractionEvent):
 @dataclass(init=False, unsafe_hash=True)
 class InsertionEvent(AbstractAgentObjectInteractionEvent):
     inserted_into_objects: List[Body] = field(init=False, default_factory=list, repr=False, hash=False)
-    inserted_into_objects_frozen_cp: List[Body] = field(init=False, default_factory=list, repr=False, hash=False)
+    inserted_into_objects_frozen_cp: List[BodyDAO] = field(init=False, default_factory=list, repr=False, hash=False)
 
     def __init__(self, inserted_object: Body,
                  inserted_into_objects: List[Body],
@@ -539,7 +547,7 @@ class InsertionEvent(AbstractAgentObjectInteractionEvent):
         super().__init__(tracked_object=inserted_object, agent=agent,
                          timestamp=timestamp, end_timestamp=end_timestamp, with_object=through_hole)
         self.inserted_into_objects: List[Body] = inserted_into_objects
-        self.inserted_into_objects_frozen_cp: List[Body] = [obj.frozen_copy() for obj in inserted_into_objects]
+        self.inserted_into_objects_frozen_cp: List[BodyDAO] = [obj.frozen_copy() for obj in inserted_into_objects]
 
     @property
     def through_hole(self) -> Body:
@@ -549,8 +557,8 @@ class InsertionEvent(AbstractAgentObjectInteractionEvent):
     def action_type(self) -> Type[PlaceAction]:
         return PlaceAction
 
-    def action_description(self) -> Type[PlaceActionDescription]:
-        return PlaceActionDescription(self.tracked_object, self.through_hole.global_pose.to_pose(), insert=True)
+    def action_description(self) -> PlaceActionDescription:
+        return PlaceActionDescription(self.tracked_object, self.through_hole.pose, insert=True)
 
     def hash_tuple(self):
         hash_tuple = (*super().hash_tuple, *(obj.name for obj in self.inserted_into_objects))

--- a/src/segmind/datastructures/events.py
+++ b/src/segmind/datastructures/events.py
@@ -2,7 +2,7 @@ import time
 from abc import abstractmethod, ABC
 from dataclasses import dataclass, field
 
-from krrood.ormatic.dao import to_dao
+from pycram.datastructures.dataclasses import Color
 from pycram.datastructures.enums import Arms
 from pycram.datastructures.partial_designator import PartialDesignator
 from typing_extensions import Optional, List, Union, Type
@@ -14,7 +14,7 @@ from segmind.datastructures.mixins import HasPrimaryTrackedObject, HasPrimaryAnd
 from segmind.datastructures.object_tracker import ObjectTrackerFactory
 from semantic_digital_twin.orm.ormatic_interface import BodyDAO
 from semantic_digital_twin.spatial_types.spatial_types import Pose
-from semantic_digital_twin.world_description.geometry import Color, BoundingBox
+from semantic_digital_twin.world_description.geometry import BoundingBox
 from semantic_digital_twin.world_description.world_entity import Body, Agent
 
 

--- a/src/segmind/datastructures/events.py
+++ b/src/segmind/datastructures/events.py
@@ -2,7 +2,7 @@ import time
 from abc import abstractmethod, ABC
 from dataclasses import dataclass, field
 
-from pycram.datastructures.dataclasses import Color
+
 from pycram.datastructures.partial_designator import PartialDesignator
 from typing_extensions import Optional, List, Union, Type
 
@@ -13,7 +13,7 @@ from segmind.datastructures.mixins import HasPrimaryTrackedObject, HasPrimaryAnd
 from segmind.datastructures.object_tracker import ObjectTrackerFactory
 from semantic_digital_twin.orm.ormatic_interface import BodyDAO
 from semantic_digital_twin.spatial_types.spatial_types import Pose
-from semantic_digital_twin.world_description.geometry import BoundingBox
+from semantic_digital_twin.world_description.geometry import BoundingBox, Color
 from semantic_digital_twin.world_description.world_entity import Body, Agent
 
 
@@ -269,8 +269,8 @@ class AbstractContactEvent(EventWithTwoTrackedObjects, ABC):
     with_object_pose: Optional[PoseStamped] = field(init=False, default=None)
 
     def __init__(self,
-                 close_bodies: list[Body],
                  of_object: Body,
+                 close_bodies: Optional[list[Body]] = None,
                  latest_close_bodies: Optional[list[Body]] = None,
                  with_object: Optional[Body] = None,
                  timestamp: Optional[float] = None):
@@ -328,7 +328,7 @@ class AbstractContactEvent(EventWithTwoTrackedObjects, ABC):
 
 
 @dataclass(init=False, unsafe_hash=True)
-class ContactEvent(AbstractContactEvent):
+class CloseContactEvent(AbstractContactEvent):
 
     @property
     def color(self) -> Color:
@@ -336,12 +336,12 @@ class ContactEvent(AbstractContactEvent):
 
     @property
     def objects(self):
-        return self.close_bodies.get_objects_that_have_points()
+        return self.close_bodies
 
     @property
     def main_link(self):
         if len(self.close_bodies) > 0:
-            return self.close_bodies[0].link_a
+            return self.close_bodies[0]
         else:
             print(f"No contact points found for {self.tracked_object.name} in {self.__class__.__name__}")
 
@@ -351,12 +351,12 @@ class ContactEvent(AbstractContactEvent):
 
 
 @dataclass(init=False, unsafe_hash=True)
-class InterferenceEvent(ContactEvent):
+class ContactEvent(CloseContactEvent):
     ...
 
 
 @dataclass(init=False, unsafe_hash=True)
-class LossOfContactEvent(AbstractContactEvent):
+class LossOfCloseContactEvent(AbstractContactEvent):
 
     @property
     def latest_objects_that_got_removed(self):
@@ -383,7 +383,7 @@ class LossOfContactEvent(AbstractContactEvent):
 
 
 @dataclass(init=False, unsafe_hash=True)
-class LossOfInterferenceEvent(LossOfContactEvent):
+class LossOfContactEvent(LossOfCloseContactEvent):
     ...
 
 
@@ -410,7 +410,7 @@ class AbstractAgentContact(AbstractContactEvent, ABC):
 
 
 @dataclass(init=False, unsafe_hash=True)
-class AgentContactEvent(ContactEvent, AbstractAgentContact):
+class AgentContactEvent(CloseContactEvent, AbstractAgentContact):
 
     @property
     def object_link(self) -> Body:
@@ -421,12 +421,12 @@ class AgentContactEvent(ContactEvent, AbstractAgentContact):
 
 
 @dataclass(init=False, unsafe_hash=True)
-class AgentInterferenceEvent(InterferenceEvent, AgentContactEvent):
+class AgentInterferenceEvent(ContactEvent, AgentContactEvent):
     ...
 
 
 @dataclass(init=False, unsafe_hash=True)
-class AgentLossOfContactEvent(LossOfContactEvent, AbstractAgentContact):
+class AgentLossOfContactEvent(LossOfCloseContactEvent, AbstractAgentContact):
 
     @property
     def object_link(self) -> Body:
@@ -437,7 +437,7 @@ class AgentLossOfContactEvent(LossOfContactEvent, AbstractAgentContact):
 
 
 @dataclass(init=False, unsafe_hash=True)
-class AgentLossOfInterferenceEvent(LossOfInterferenceEvent, AgentLossOfContactEvent):
+class AgentLossOfInterferenceEvent(LossOfContactEvent, AgentLossOfContactEvent):
     ...
 
 
@@ -582,8 +582,8 @@ class ContainmentEvent(DefaultEventWithTwoTrackedObjects):
 EventUnion = Union[NewObjectEvent,
 MotionEvent,
 StopMotionEvent,
-ContactEvent,
-LossOfContactEvent,
+CloseContactEvent,
+LossOfCloseContactEvent,
 AgentContactEvent,
 AgentLossOfContactEvent,
 PickUpEvent,

--- a/src/segmind/datastructures/events.py
+++ b/src/segmind/datastructures/events.py
@@ -2,17 +2,17 @@ import time
 from abc import abstractmethod, ABC
 from dataclasses import dataclass, field
 
-from pycram.datastructures.dataclasses import Color, ContactPoint
-from pycram.datastructures.dataclasses import ContactPointsList, ObjectState, AxisAlignedBoundingBox, \
-    FrozenObject, FrozenBody
+from pycram.datastructures.dataclasses import Color
+from pycram.datastructures.enums import Arms
 from pycram.datastructures.partial_designator import PartialDesignator
-from pycram.datastructures.pose import Pose, PoseStamped
-from pycram.datastructures.world_entity import PhysicalBody
-from pycram.designator import ActionDescription
-from pycram.designators.action_designator import PickUpActionDescription, PlaceActionDescription, PickUpAction, \
-    PlaceAction
-from pycram.ros import logwarn, logdebug
-from pycram.world_concepts.world_object import Object, Link
+from pycram.datastructures.pose import PoseStamped
+from pycram.robot_plans import ActionDescription, PlaceAction, PickUpAction, PlaceActionDescription, \
+    PickUpActionDescription
+from semantic_digital_twin.collision_checking.collision_detector import Collision
+from semantic_digital_twin.collision_checking.trimesh_collision_detector import TrimeshCollisionDetector
+from semantic_digital_twin.spatial_types.spatial_types import Pose
+from semantic_digital_twin.world_description.geometry import BoundingBox
+from semantic_digital_twin.world_description.world_entity import Body, Agent
 from typing_extensions import Optional, List, Union, Type
 
 from segmind.datastructures.mixins import HasPrimaryTrackedObject, HasPrimaryAndSecondaryTrackedObjects
@@ -73,7 +73,7 @@ class EventWithTrackedObjects(Event, ABC):
 
     @property
     @abstractmethod
-    def tracked_objects(self) -> List[Object]:
+    def tracked_objects(self) -> List[Body]:
         """
         The tracked objects involved in the event.
         """
@@ -81,7 +81,7 @@ class EventWithTrackedObjects(Event, ABC):
 
     @property
     @abstractmethod
-    def involved_bodies(self) -> List[PhysicalBody]:
+    def involved_bodies(self) -> List[Body]:
         """
         The bodies involved in the event.
         """
@@ -102,7 +102,7 @@ class EventWithOneTrackedObject(EventWithTrackedObjects, HasPrimaryTrackedObject
     """
 
     @property
-    def tracked_objects(self) -> List[Object]:
+    def tracked_objects(self) -> List[Body]:
         return [self.tracked_object]
 
     def update_object_trackers_with_event(self) -> None:
@@ -127,7 +127,7 @@ class EventWithTwoTrackedObjects(EventWithTrackedObjects, HasPrimaryAndSecondary
     """
 
     @property
-    def tracked_objects(self) -> List[Object]:
+    def tracked_objects(self) -> List[Body]:
         return [self.tracked_object, self.with_object] if self.with_object is not None else [self.tracked_object]
 
     def update_object_trackers_with_event(self) -> None:
@@ -160,7 +160,7 @@ class DefaultEventWithTwoTrackedObjects(EventWithTwoTrackedObjects):
     """
 
     @property
-    def involved_bodies(self) -> List[PhysicalBody]:
+    def involved_bodies(self) -> List[Body]:
         return self.tracked_objects
 
     def set_color(self, color: Color):
@@ -178,7 +178,7 @@ class NewObjectEvent(EventWithOneTrackedObject):
     """
 
     @property
-    def involved_bodies(self) -> List[Object]:
+    def involved_bodies(self) -> List[Body]:
         return self.tracked_objects
 
     def set_color(self, color: Color):
@@ -215,7 +215,7 @@ class MotionEvent(EventWithOneTrackedObject, ABC):
     start_pose: PoseStamped = field(init=False)
     current_pose: PoseStamped = field(init=False)
 
-    def __init__(self, tracked_object: Object, start_pose: PoseStamped, current_pose: PoseStamped,
+    def __init__(self, tracked_object: Body, start_pose: PoseStamped, current_pose: PoseStamped,
                  timestamp: Optional[float] = None):
         EventWithOneTrackedObject.__init__(self, tracked_object=tracked_object,
                                            timestamp=timestamp if timestamp is not None else time.time())
@@ -223,7 +223,7 @@ class MotionEvent(EventWithOneTrackedObject, ABC):
         self.current_pose: PoseStamped = current_pose
 
     @property
-    def involved_bodies(self) -> List[PhysicalBody]:
+    def involved_bodies(self) -> List[Body]:
         return self.tracked_objects
 
     def set_color(self, color: Color):
@@ -263,33 +263,36 @@ class StopRotationEvent(StopMotionEvent):
 
 @dataclass(init=False, unsafe_hash=True)
 class AbstractContactEvent(EventWithTwoTrackedObjects, ABC):
-    contact_points: ContactPointsList = field(init=False, default_factory=ContactPointsList)
-    latest_contact_points: ContactPointsList = field(init=False, default_factory=ContactPointsList)
-    bounding_box: AxisAlignedBoundingBox = field(init=False)
+    contact_points: Collision = field(init=False, default_factory=Collision)
+    latest_contact_points: Collision = field(init=False, default_factory=Collision)
+    bounding_box: BoundingBox = field(init=False)
     pose: PoseStamped = field(init=False)
-    with_object_bounding_box: Optional[AxisAlignedBoundingBox] = field(init=False, default=None)
+    with_object_bounding_box: Optional[BoundingBox] = field(init=False, default=None)
     with_object_pose: Optional[PoseStamped] = field(init=False, default=None)
 
     def __init__(self,
-                 contact_points: ContactPointsList,
-                 of_object: Object,
-                 latest_contact_points: Optional[ContactPointsList] = None,
-                 with_object: Optional[Object] = None,
+                 contact_points: Collision,
+                 of_object: Body,
+                 latest_contact_points: Optional[Collision] = None,
+                 with_object: Optional[Body] = None,
                  timestamp: Optional[float] = None):
         EventWithTwoTrackedObjects.__init__(self,
                                             tracked_object=of_object,
                                             with_object=with_object,
                                             timestamp=timestamp if timestamp is not None else time.time())
-        self.contact_points: ContactPointsList = contact_points
-        self.latest_contact_points: ContactPointsList = latest_contact_points
-        self.bounding_box: AxisAlignedBoundingBox = of_object.get_axis_aligned_bounding_box()
-        self.pose: PoseStamped = of_object.pose
-        self.with_object_bounding_box: Optional[AxisAlignedBoundingBox] = with_object.get_axis_aligned_bounding_box() \
+        self.contact_points: TrimeshCollisionDetector = contact_points
+        self.latest_contact_points: TrimeshCollisionDetector = latest_contact_points
+        self.bounding_box: BoundingBox = BoundingBox.from_mesh(
+            of_object.collision.combined_mesh,
+            origin=of_object.global_pose
+        )
+        self.pose: Pose = of_object.global_pose.to_pose()
+        self.with_object_bounding_box: Optional[BoundingBox] = with_object.get_axis_aligned_bounding_box() \
             if with_object is not None else None
         self.with_object_pose: Optional[PoseStamped] = with_object.pose if with_object is not None else None
 
     @property
-    def involved_bodies(self) -> List[PhysicalBody]:
+    def involved_bodies(self) -> List[Body]:
         return list(set(self.links))
 
     def set_color(self, color: Color):
@@ -306,17 +309,17 @@ class AbstractContactEvent(EventWithTwoTrackedObjects, ABC):
 
     @property
     @abstractmethod
-    def main_link(self) -> PhysicalBody:
+    def main_link(self) -> Body:
         pass
 
     @property
     @abstractmethod
-    def links(self) -> List[PhysicalBody]:
+    def links(self) -> List[Body]:
         pass
 
     @property
     @abstractmethod
-    def objects(self) -> List[Object]:
+    def objects(self) -> List[Body]:
         pass
 
 
@@ -336,7 +339,7 @@ class ContactEvent(AbstractContactEvent):
         if len(self.contact_points) > 0:
             return self.contact_points[0].link_a
         else:
-            logwarn(f"No contact points found for {self.tracked_object.name} in {self.__class__.__name__}")
+            print(f"No contact points found for {self.tracked_object.name} in {self.__class__.__name__}")
 
     @property
     def links(self):
@@ -355,7 +358,7 @@ class LossOfContactEvent(AbstractContactEvent):
     def latest_objects_that_got_removed(self):
         return self.get_objects_that_got_removed(self.latest_contact_points)
 
-    def get_objects_that_got_removed(self, contact_points: ContactPointsList):
+    def get_objects_that_got_removed(self, contact_points: TrimeshCollisionDetector):
         return self.contact_points.get_objects_that_got_removed(contact_points)
 
     @property
@@ -363,11 +366,11 @@ class LossOfContactEvent(AbstractContactEvent):
         return Color(1, 0, 0, 1)
 
     @property
-    def main_link(self) -> PhysicalBody:
+    def main_link(self) -> Body:
         return self.latest_contact_points[0].link_a
 
     @property
-    def links(self) -> List[PhysicalBody]:
+    def links(self) -> List[Body]:
         return self.contact_points.get_bodies_that_got_removed(self.latest_contact_points)
 
     @property
@@ -383,14 +386,14 @@ class LossOfInterferenceEvent(LossOfContactEvent):
 @dataclass(init=False, unsafe_hash=True)
 class AbstractAgentContact(AbstractContactEvent, ABC):
     @property
-    def agent(self) -> Object:
+    def agent(self) -> Body:
         return self.tracked_object
 
     @property
-    def agent_link(self) -> PhysicalBody:
+    def agent_link(self) -> Body:
         return self.main_link
 
-    def with_object_contact_link(self) -> Optional[PhysicalBody]:
+    def with_object_contact_link(self) -> Optional[Body]:
         if self.with_object is not None:
             return [link for link in self.links if link.parent_entity == self.with_object][0]
         else:
@@ -398,7 +401,7 @@ class AbstractAgentContact(AbstractContactEvent, ABC):
 
     @property
     @abstractmethod
-    def object_link(self) -> Link:
+    def object_link(self) -> Body:
         pass
 
 
@@ -406,7 +409,7 @@ class AbstractAgentContact(AbstractContactEvent, ABC):
 class AgentContactEvent(ContactEvent, AbstractAgentContact):
 
     @property
-    def object_link(self) -> PhysicalBody:
+    def object_link(self) -> Body:
         if self.with_object is not None:
             return self.with_object_contact_link()
         else:
@@ -422,7 +425,7 @@ class AgentInterferenceEvent(InterferenceEvent, AgentContactEvent):
 class AgentLossOfContactEvent(LossOfContactEvent, AbstractAgentContact):
 
     @property
-    def object_link(self) -> PhysicalBody:
+    def object_link(self) -> Body:
         if self.with_object is not None:
             return self.with_object_contact_link()
         else:
@@ -436,10 +439,10 @@ class AgentLossOfInterferenceEvent(LossOfInterferenceEvent, AgentLossOfContactEv
 
 @dataclass(kw_only=True)
 class AbstractAgentObjectInteractionEvent(EventWithTwoTrackedObjects, ABC):
-    agent: Optional[Object] = None
+    agent: Optional[Body] = None
     timestamp: Optional[float] = None
     end_timestamp: Optional[float] = None
-    agent_frozen_cp: Optional[FrozenObject] = field(init=False, default=None, repr=False, hash=False)
+    agent_frozen_cp: Optional[Body] = field(init=False, default=None, repr=False, hash=False)
 
     def __post_init__(self):
         EventWithTwoTrackedObjects.__post_init__(self)
@@ -447,11 +450,11 @@ class AbstractAgentObjectInteractionEvent(EventWithTwoTrackedObjects, ABC):
             self.agent_frozen_cp = self.agent.frozen_copy()
 
     @property
-    def involved_bodies(self) -> List[PhysicalBody]:
+    def involved_bodies(self) -> List[Body]:
         return self.tracked_objects
 
     @property
-    def agent_state(self) -> Optional[ObjectState]:
+    def agent_state(self) -> Optional[Agent]:
         if self.agent is None:
             return None
         return self.agent.state
@@ -500,7 +503,7 @@ class PickUpEvent(AbstractAgentObjectInteractionEvent):
     def color(self) -> Color:
         return Color(0, 1, 0, 1)
 
-    def action_description(self) -> PickUpActionDescription:
+    def action_description(self) -> Type[PickUpActionDescription]:
         return PickUpActionDescription(self.tracked_object)
 
     @property
@@ -516,10 +519,10 @@ class PlacingEvent(AbstractAgentObjectInteractionEvent):
     def color(self) -> Color:
         return Color(1, 0, 1, 1)
 
-    def action_description(self, pose: Optional[PoseStamped] = None) -> PlaceActionDescription:
+    def action_description(self, pose: Optional[PoseStamped] = None, arm: Optional[Arms] = None) -> Type[PlaceActionDescription]:
         if pose is None:
             pose = self.tracked_object.pose
-        return PlaceActionDescription(self.tracked_object, pose)
+        return PlaceActionDescription(self.tracked_object, pose, arm)
 
     @property
     def action_type(self) -> Type[PlaceAction]:
@@ -528,30 +531,30 @@ class PlacingEvent(AbstractAgentObjectInteractionEvent):
 
 @dataclass(init=False, unsafe_hash=True)
 class InsertionEvent(AbstractAgentObjectInteractionEvent):
-    inserted_into_objects: List[Object] = field(init=False, default_factory=list, repr=False, hash=False)
-    inserted_into_objects_frozen_cp: List[FrozenObject] = field(init=False, default_factory=list, repr=False, hash=False)
+    inserted_into_objects: List[Body] = field(init=False, default_factory=list, repr=False, hash=False)
+    inserted_into_objects_frozen_cp: List[Body] = field(init=False, default_factory=list, repr=False, hash=False)
 
-    def __init__(self, inserted_object: Object,
-                 inserted_into_objects: List[Object],
-                 through_hole: PhysicalBody,
-                 agent: Optional[Object] = None,
+    def __init__(self, inserted_object: Body,
+                 inserted_into_objects: List[Body],
+                 through_hole: Body,
+                 agent: Optional[Body] = None,
                  timestamp: Optional[float] = None,
                  end_timestamp: Optional[float] = None):
         super().__init__(tracked_object=inserted_object, agent=agent,
                          timestamp=timestamp, end_timestamp=end_timestamp, with_object=through_hole)
-        self.inserted_into_objects: List[Object] = inserted_into_objects
-        self.inserted_into_objects_frozen_cp: List[FrozenObject] = [obj.frozen_copy() for obj in inserted_into_objects]
+        self.inserted_into_objects: List[Body] = inserted_into_objects
+        self.inserted_into_objects_frozen_cp: List[Body] = [obj.frozen_copy() for obj in inserted_into_objects]
 
     @property
-    def through_hole(self) -> PhysicalBody:
+    def through_hole(self) -> Body:
         return self.with_object
 
     @property
     def action_type(self) -> Type[PlaceAction]:
         return PlaceAction
 
-    def action_description(self) -> PlaceActionDescription:
-        return PlaceActionDescription(self.tracked_object, self.through_hole.pose, insert=True)
+    def action_description(self) -> Type[PlaceActionDescription]:
+        return PlaceActionDescription(self.tracked_object, self.through_hole.global_pose)
 
     def hash_tuple(self):
         hash_tuple = (*super().hash_tuple, *(obj.name for obj in self.inserted_into_objects))

--- a/src/segmind/datastructures/events.py
+++ b/src/segmind/datastructures/events.py
@@ -263,33 +263,39 @@ class StopRotationEvent(StopMotionEvent):
 
 @dataclass(init=False, unsafe_hash=True)
 class AbstractContactEvent(EventWithTwoTrackedObjects, ABC):
-    contact_points: Collision = field(init=False, default_factory=Collision)
-    latest_contact_points: Collision = field(init=False, default_factory=Collision)
+    contact_points: list[Collision] = field(init=False, default_factory=list)
+    latest_contact_points: list[Collision] = field(init=False, default_factory=list)
     bounding_box: BoundingBox = field(init=False)
     pose: PoseStamped = field(init=False)
     with_object_bounding_box: Optional[BoundingBox] = field(init=False, default=None)
     with_object_pose: Optional[PoseStamped] = field(init=False, default=None)
 
     def __init__(self,
-                 contact_points: Collision,
+                 contact_points: list[Collision],
                  of_object: Body,
-                 latest_contact_points: Optional[Collision] = None,
+                 latest_contact_points: Optional[list[Collision]] = None,
                  with_object: Optional[Body] = None,
                  timestamp: Optional[float] = None):
         EventWithTwoTrackedObjects.__init__(self,
                                             tracked_object=of_object,
                                             with_object=with_object,
                                             timestamp=timestamp if timestamp is not None else time.time())
-        self.contact_points: TrimeshCollisionDetector = contact_points
-        self.latest_contact_points: TrimeshCollisionDetector = latest_contact_points
+        self.contact_points: list[Collision] = contact_points
+        self.latest_contact_points: list[Collision] = latest_contact_points if latest_contact_points is not None else []
         self.bounding_box: BoundingBox = BoundingBox.from_mesh(
             of_object.collision.combined_mesh,
             origin=of_object.global_pose
         )
         self.pose: Pose = of_object.global_pose.to_pose()
-        self.with_object_bounding_box: Optional[BoundingBox] = with_object.get_axis_aligned_bounding_box() \
-            if with_object is not None else None
-        self.with_object_pose: Optional[PoseStamped] = with_object.pose if with_object is not None else None
+        self.with_object_bounding_box: Optional[BoundingBox] = (
+            BoundingBox.from_mesh(
+                with_object.collision.combined_mesh,
+                origin=with_object.global_pose.from_xyz_rpy(),
+            )
+            if with_object is not None
+            else None
+        )
+        self.with_object_pose: Optional[Pose] = with_object.global_pose.to_pose() if with_object is not None else None
 
     @property
     def involved_bodies(self) -> List[Body]:
@@ -332,18 +338,20 @@ class ContactEvent(AbstractContactEvent):
 
     @property
     def objects(self):
-        return self.contact_points.get_objects_that_have_points()
+        from segmind.detectors.atomic_event_detectors import AbstractContactDetector
+        return AbstractContactDetector.get_bodies_in_contact(self.contact_points)
 
     @property
     def main_link(self):
         if len(self.contact_points) > 0:
-            return self.contact_points[0].link_a
+            return self.contact_points[0].body_a
         else:
             print(f"No contact points found for {self.tracked_object.name} in {self.__class__.__name__}")
 
     @property
     def links(self):
-        return self.contact_points.get_all_bodies()
+        from segmind.detectors.atomic_event_detectors import AbstractContactDetector
+        return AbstractContactDetector.get_bodies_in_contact(self.contact_points)
 
 
 @dataclass(init=False, unsafe_hash=True)
@@ -356,10 +364,12 @@ class LossOfContactEvent(AbstractContactEvent):
 
     @property
     def latest_objects_that_got_removed(self):
-        return self.get_objects_that_got_removed(self.latest_contact_points)
-
-    def get_objects_that_got_removed(self, contact_points: TrimeshCollisionDetector):
-        return self.contact_points.get_objects_that_got_removed(contact_points)
+        prev_contacts = {
+            (cp.body_a, cp.body_b) for cp in self.latest_contact_points
+        }
+        curr_contacts = {(cp.body_a, cp.body_b) for cp in self.contact_points}
+        lost_contact_pairs = prev_contacts - curr_contacts
+        return list({b for (a, b) in lost_contact_pairs if a == self.tracked_object})
 
     @property
     def color(self) -> Color:
@@ -367,15 +377,17 @@ class LossOfContactEvent(AbstractContactEvent):
 
     @property
     def main_link(self) -> Body:
-        return self.latest_contact_points[0].link_a
+        if len(self.latest_contact_points) > 0:
+            return self.latest_contact_points[0].body_a
+        return self.tracked_object
 
     @property
     def links(self) -> List[Body]:
-        return self.contact_points.get_bodies_that_got_removed(self.latest_contact_points)
+        return self.latest_objects_that_got_removed
 
     @property
-    def objects(self):
-        return self.contact_points.get_objects_that_got_removed(self.latest_contact_points)
+    def objects(self) -> List[Body]:
+        return self.latest_objects_that_got_removed
 
 
 @dataclass(init=False, unsafe_hash=True)

--- a/src/segmind/datastructures/mixins.py
+++ b/src/segmind/datastructures/mixins.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from functools import cached_property
 
-from pycram.world_concepts.world_object import Object
+from pycram.orm.ormatic_interface import BodyDAO
+from semantic_digital_twin.world_description.world_entity import Body
 from typing_extensions import List, Optional, TYPE_CHECKING
 
 from .object_tracker import ObjectTrackerFactory, ObjectTracker
-
-from pycram.datastructures.dataclasses import ObjectState, FrozenObject, FrozenWorldState
 
 
 @dataclass
@@ -16,10 +15,10 @@ class HasTrackedObjects:
     """
     A mixin class that provides the tracked object for the event.
     """
-    _involved_objects: List[Object]
+    _involved_objects: List[Body]
 
     @property
-    def involved_objects(self) -> List[Object]:
+    def involved_objects(self) -> List[Body]:
         """
         The objects involved in the event.
         """
@@ -31,17 +30,16 @@ class HasPrimaryTrackedObject:
     """
     A mixin class that provides the tracked object for the event.
     """
-    tracked_object: Object
-    tracked_object_frozen_cp: Optional[FrozenObject] = field(init=False, default=None, repr=False, hash=False)
-    world_frozen_cp: Optional[FrozenWorldState] = field(init=False, default=None, repr=False, hash=False)
+    tracked_object: Body
+    tracked_object_frozen_cp: Optional[BodyDAO] = field(init=False, default=None, repr=False, hash=False)
 
     def __post_init__(self):
-        self.tracked_object_frozen_cp = self.tracked_object.frozen_copy()
-        self.world_frozen_cp = self.tracked_object.world.frozen_copy()
+        self.tracked_object_frozen_cp = self.tracked_object_frozen_cp
+        self.world_frozen_cp = self.tracked_object._world.__deepcopy__(
+            memo={id(self.tracked_object._world): self.tracked_object._world}
+        )
 
-    @property
-    def tracked_object_state(self) -> ObjectState:
-        return self.tracked_object.current_state
+
 
     @cached_property
     def object_tracker(self) -> ObjectTracker:
@@ -53,16 +51,13 @@ class HasSecondaryTrackedObject:
     """
     A mixin class that provides the tracked objects for the event.
     """
-    with_object: Optional[Object] = None
-    with_object_frozen_cp: Optional[FrozenObject] = field(init=False, default=None, repr=False, hash=False)
+    with_object: Optional[Body] = None
+    with_object_frozen_cp: Optional[BodyDAO] = field(init=False, default=None, repr=False, hash=False)
 
     def __post_init__(self):
         if self.with_object is not None:
             self.with_object_frozen_cp = self.with_object.frozen_copy()
 
-    @property
-    def with_object_state(self) -> Optional[ObjectState]:
-        return self.with_object.current_state if self.with_object is not None else None
 
     @cached_property
     def with_object_tracker(self) -> Optional[ObjectTracker]:

--- a/src/segmind/datastructures/mixins.py
+++ b/src/segmind/datastructures/mixins.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from functools import cached_property
 
-from pycram.orm.ormatic_interface import BodyDAO
+import semantic_digital_twin
+from krrood.ormatic.dao import to_dao, DataAccessObjectState, DataAccessObject
+from semantic_digital_twin.orm.ormatic_interface import BodyDAO
 from semantic_digital_twin.world_description.world_entity import Body
 from typing_extensions import List, Optional, TYPE_CHECKING
 
@@ -52,11 +54,11 @@ class HasSecondaryTrackedObject:
     A mixin class that provides the tracked objects for the event.
     """
     with_object: Optional[Body] = None
-    with_object_frozen_cp: Optional[BodyDAO] = field(init=False, default=None, repr=False, hash=False)
+    with_object_frozen_cp: Optional[DataAccessObject[Body]] = field(init=False, default=None, repr=False, hash=False)
 
     def __post_init__(self):
         if self.with_object is not None:
-            self.with_object_frozen_cp = self.with_object.frozen_copy()
+            self.with_object_frozen_cp = to_dao(self.with_object)
 
 
     @cached_property

--- a/src/segmind/datastructures/object_tracker.py
+++ b/src/segmind/datastructures/object_tracker.py
@@ -53,7 +53,7 @@ class ObjectTracker:
         with self._lock:
             self._event_history.append(event)
             self._event_history.sort(key=lambda e: e.timestamp)
-        if isinstance(self.obj, Body):
+        if isinstance(self.obj, Body) and hasattr(self.obj, "parent_entity") and self.obj.parent_entity:
             ObjectTrackerFactory.get_tracker(self.obj.parent_entity).add_event(event)
 
     def get_event_history(self) -> List[Event]:

--- a/src/segmind/datastructures/object_tracker.py
+++ b/src/segmind/datastructures/object_tracker.py
@@ -4,15 +4,10 @@ from datetime import timedelta
 from threading import RLock
 from typing import Callable, Tuple
 
+from semantic_digital_twin.world_description.world_entity import Body
 from typing_extensions import List, Type, Optional, TYPE_CHECKING, Dict, Set
 
 import numpy as np
-
-from pycram.world_concepts.world_object import Object
-from pycram.ros import logwarn
-from pycram.description import RootLink, Link
-from pycram.datastructures.dataclasses import ObjectState
-from pycram.datastructures.world_entity import PhysicalBody
 
 if TYPE_CHECKING:
     from .events import Event, EventUnion
@@ -21,19 +16,19 @@ if TYPE_CHECKING:
 
 class ObjectTracker:
 
-    def __init__(self, obj: PhysicalBody):
+    def __init__(self, obj: Body):
         self.obj = obj
         self._lock: RLock = RLock()
         self._event_history: List[Event] = []
         self._current_detectors: List[DetectorWithStarterEvent] = []
-        self._support: Optional[PhysicalBody] = None
+        self._support: Optional[Body] = None
 
     @property
-    def support(self) -> Optional[PhysicalBody]:
+    def support(self) -> Optional[Body]:
         return self._support
 
     @support.setter
-    def support(self, support: PhysicalBody):
+    def support(self, support: Body):
         with self._lock:
             self._support = support
 
@@ -51,14 +46,14 @@ class ObjectTracker:
         self._event_history = []
 
     @property
-    def current_state(self) -> ObjectState:
+    def current_state(self) -> Body:
         return self.obj.current_state
 
     def add_event(self, event: Event):
         with self._lock:
             self._event_history.append(event)
             self._event_history.sort(key=lambda e: e.timestamp)
-        if isinstance(self.obj, Link):
+        if isinstance(self.obj, Body):
             ObjectTrackerFactory.get_tracker(self.obj.parent_entity).add_event(event)
 
     def get_event_history(self) -> List[Event]:
@@ -172,7 +167,7 @@ class ObjectTracker:
             try:
                 return np.where(time_stamps > timestamp)[0][0]
             except IndexError:
-                logwarn(f"No events after timestamp {timestamp}")
+                print(f"No events after timestamp {timestamp}")
                 return None
 
     def get_index_of_first_event_before(self, timestamp: float) -> Optional[int]:
@@ -181,7 +176,7 @@ class ObjectTracker:
             try:
                 return np.where(time_stamps < timestamp)[0][-1]
             except IndexError:
-                logwarn(f"No events before timestamp {timestamp}")
+                print(f"No events before timestamp {timestamp}")
                 return None
 
     def get_events_between_two_events(self, event1: Event, event2: Event) -> List[Event]:
@@ -198,7 +193,7 @@ class ObjectTracker:
                 events = [self._event_history[i] for i in indices]
                 return events
             except IndexError:
-                logwarn(f"No events between timestamps {timestamp1}, {timestamp2}")
+                print(f"No events between timestamps {timestamp1}, {timestamp2}")
                 return []
 
     def get_event_where(self, conditions: Callable[[Event], bool], events: Optional[List[Event]] = None) -> List[Event]:
@@ -217,7 +212,7 @@ class ObjectTracker:
 
 class ObjectTrackerFactory:
 
-    _trackers: Dict[PhysicalBody, ObjectTracker] = {}
+    _trackers: Dict[Body, ObjectTracker] = {}
     _lock: RLock = RLock()
 
     @classmethod
@@ -226,7 +221,7 @@ class ObjectTrackerFactory:
             return list(cls._trackers.values())
 
     @classmethod
-    def get_tracker(cls, obj: PhysicalBody) -> ObjectTracker:
+    def get_tracker(cls, obj: Body) -> ObjectTracker:
         with cls._lock:
             if obj not in cls._trackers:
                 cls._trackers[obj] = ObjectTracker(obj)

--- a/src/segmind/detectors/atomic_event_detectors.py
+++ b/src/segmind/detectors/atomic_event_detectors.py
@@ -7,16 +7,12 @@ from queue import Queue, Empty, Full
 
 import numpy as np
 
-from pycram.datastructures.pose import PoseStamped
-from semantic_digital_twin.collision_checking.collision_detector import Collision, CollisionCheck
-from semantic_digital_twin.collision_checking.trimesh_collision_detector import TrimeshCollisionDetector
+from semantic_digital_twin.collision_checking.collision_detector import Collision
+from semantic_digital_twin.reasoning.predicates import contact
 from semantic_digital_twin.spatial_types.spatial_types import Pose
 from semantic_digital_twin.world import World
 from semantic_digital_twin.world_description.world_entity import Body, Agent
-
-from .. import logger, set_logger_level, LogLevel
-from ..datastructures.mixins import HasPrimaryTrackedObject, HasSecondaryTrackedObject, \
-    HasPrimaryAndSecondaryTrackedObjects
+from ..datastructures.mixins import HasPrimaryTrackedObject,HasPrimaryAndSecondaryTrackedObjects
 from ..detectors.motion_detection_helpers import is_displaced, is_stopped, \
     ExponentialMovingAverage
 from ..episode_player import EpisodePlayer
@@ -36,7 +32,7 @@ from .motion_detection_helpers import DataFilter
 from ..utils import calculate_quaternion_difference, \
     calculate_translation, PropagatingThread
 
-set_logger_level(LogLevel.DEBUG)
+
 class AtomicEventDetector(PropagatingThread):
     """
     A thread that detects events in another thread and logs them. The event detector is a function that has no arguments
@@ -62,7 +58,7 @@ class AtomicEventDetector(PropagatingThread):
         self.logger: EventLogger = logger if logger else EventLogger.current_logger
         self.world: World = world
         self.wait_time = wait_time if wait_time is not None else timedelta(milliseconds=50)
-        self.tcd = TrimeshCollisionDetector(self.world)
+
         self.queues: List[Queue] = []
 
         self.run_once = False
@@ -138,8 +134,7 @@ class AtomicEventDetector(PropagatingThread):
         """
         events = self.detect_events()
         if events:
-            for event in events:
-                self.log_event(event)
+            [self.log_event(event) for event in events]
 
     def _wait_if_paused(self):
         """
@@ -202,12 +197,12 @@ class NewObjectDetector(AtomicEventDetector):
         self.avoid_objects = avoid_objects if avoid_objects else lambda obj: False
         #self.world.add_callback_on_add_object(self.on_add_object)
 
-    def on_add_object(self, body: Body):
+    def on_add_object(self, obj: Body):
         """
         Callback function that is called when a new object is added to the scene.
         """
-        if not self.avoid_objects(body):
-            self.new_object_queue.put(body)
+        if not self.avoid_objects(obj):
+            self.new_object_queue.put(obj)
 
     def detect_events(self) -> List[Event]:
         """
@@ -228,8 +223,8 @@ class NewObjectDetector(AtomicEventDetector):
         """
         Remove the callback on the add object event and resume the thread to be able to join.
         """
-        if self.world is not None:
-            self.world.remove_callback_on_add_object(self.on_add_object)
+        #if self.world is not None:
+        #    self.world.remove_callback_on_add_object(self.on_add_object)
         super().stop()
 
     def _join(self, timeout=None):
@@ -248,7 +243,7 @@ class DetectorWithTrackedObject(AtomicEventDetector, HasPrimaryTrackedObject, AB
                  *args, **kwargs):
         """
         :param logger: An instance of the EventLogger class that is used to log the events.
-        :param tracked_object: An Object instance that represents the object to track.
+        :param tracked_object: An Body instance that represents the object to track.
         :param wait_time: An optional timedelta value that introduces a delay between calls to the event detector.
         """
         HasPrimaryTrackedObject.__init__(self, tracked_object=tracked_object)
@@ -267,8 +262,8 @@ class DetectorWithTwoTrackedObjects(AtomicEventDetector, HasPrimaryAndSecondaryT
                  wait_time: Optional[timedelta] = None, *args, **kwargs):
         """
         :param logger: An instance of the EventLogger class that is used to log the events.
-        :param tracked_object: An Object instance that represents the object to track.
-        :param with_object: An optional Object instance that represents the object to track.
+        :param tracked_object: An Body instance that represents the object to track.
+        :param with_object: An optional Body instance that represents the object to track.
         :param wait_time: An optional timedelta value that introduces a delay between calls to the event detector.
         """
         HasPrimaryAndSecondaryTrackedObjects.__init__(self, tracked_object=tracked_object, with_object=with_object)
@@ -294,44 +289,32 @@ class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
         DetectorWithTwoTrackedObjects.__init__(self, logger, tracked_object, with_object, wait_time,
                                                *args, **kwargs)
         self.max_closeness_distance = max_closeness_distance
-        self.latest_contact_points: List[Collision] = []
-        self.latest_interference_points: List[Collision] = []
+        self.latest_contact_bodies: Optional[list[Body]]
+        self.latest_interference_bodies: Optional[list[Body]]
 
-    def get_events(self, new_objects_contact: List[Body], new_bodies_interference: List[Body],
-                   contact_points: list[Collision], interference_points: list[Collision],
-                   event_type: Type[AbstractContactEvent]):
+    def get_events(self, new_objects_contact: List[Body], contact_bodies: list[Body], event_type: Type[AbstractContactEvent]):
         if event_type is ContactEvent:
             contact_event_type = ContactEvent
             agent_contact_event_type = AgentContactEvent
-            interference_event_type = InterferenceEvent
-            agent_interference_event_type = AgentInterferenceEvent
         elif event_type is LossOfContactEvent:
             contact_event_type = LossOfContactEvent
             agent_contact_event_type = AgentLossOfContactEvent
-            interference_event_type = LossOfInterferenceEvent
-            agent_interference_event_type = AgentLossOfInterferenceEvent
         else:
             raise NotImplementedError(f"Invalid event type {event_type}")
         events = []
-        for body in new_bodies_interference:
-            if issubclass(self.obj_type, Agent):
-                event_type = agent_interference_event_type
-            else:
-                event_type = interference_event_type
-            events.append(event_type(contact_points=self.get_points_of_body(interference_points, body),
-                                     latest_contact_points=self.latest_interference_points,
-                                     of_object=self.tracked_object, with_object=body))
         for obj in new_objects_contact:
-            if obj in new_bodies_interference:
-                continue
+            if issubclass(self.obj_type, Agent):
+                event_type = agent_contact_event_type
             else:
-                if issubclass(self.obj_type, Agent):
-                    event_type = agent_contact_event_type
-                else:
-                    event_type = contact_event_type
-                events.append(event_type(contact_points=self.get_points_of_object(contact_points, obj),
-                                         latest_contact_points=self.latest_contact_points,
-                                         of_object=self.tracked_object, with_object=obj))
+                event_type = contact_event_type
+
+            contact_bodies = []
+            for i in self.world.bodies_with_enabled_collision:
+                if contact(obj, i):
+                    contact_bodies.append(i)
+            events.append(event_type(contact_points=contact_bodies,
+                                     latest_contact_points=self.latest_contact_bodies,
+                                     of_object=self.tracked_object, with_object=obj))
         return events
 
     @property
@@ -346,77 +329,29 @@ class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
         Detects the closest points between the object to track and another object in the scene if the with_object
         attribute is set, else, between the object to track and all other objects in the scene.
         """
-        #logger.debug("Getting contact points...")
-        contact_points, interference_points = self.get_contact_points()
-        #logger.debug(f"Contact points: {contact_points=}, {interference_points=}")
-        events = self.trigger_events(contact_points, interference_points)
+        contact_bodies = self.get_contact_bodies()
 
-        self.latest_contact_points = contact_points
-        self.latest_interference_points = interference_points
+        events = self.trigger_events(contact_bodies)
+
+        self.latest_contact_bodies = contact_bodies
 
         return events
 
-    def get_contact_points(self) -> Tuple[list[Collision], list[Collision]]:
-        return self.get_contact_points_for_body(self.tracked_object, self.max_closeness_distance, self.with_object)
+    def get_contact_bodies(self) -> list[Body]:
+        contact_bodies = []
+        if self.with_object:
+            if contact(self.tracked_object, self.with_object):
+                contact_bodies.append(self.with_object)
 
-    @staticmethod
-    def get_contact_points_for_body(tracked_object: Body, max_closeness_distance: float,
-                                   with_object: Optional[Body] = None) -> Tuple[list[Collision], list[Collision]]:
-        world = tracked_object._world
-        collision_detector = TrimeshCollisionDetector(world)
-        collision_matrix = []
-        if with_object is not None:
-            try:
-                collision_matrix.append(
-                    CollisionCheck(tracked_object, with_object, max_closeness_distance, world))
-            except ValueError:
-                pass
         else:
-            for body in world.bodies_with_enabled_collision:
-                if body == tracked_object:
-                    continue
-                try:
-                    collision_matrix.append(
-                        CollisionCheck(tracked_object, body, max_closeness_distance, world))
-                except ValueError:
-                    continue
+            for obj in self.world.bodies_with_enabled_collision:
+                if contact(self.tracked_object, obj):
+                    contact_bodies.append(obj)
 
-        if not collision_matrix:
-            return [], []
-
-        logger.debug(f"Collision matrix: {collision_matrix=}")
-        all_collisions = collision_detector.check_collisions(collision_matrix)
-        contact_points = [c for c in all_collisions if c.contact_distance <= max_closeness_distance]
-        interference_points = [c for c in all_collisions if c.contact_distance <= 0]
-
-        # For contact/interference, body_a should always be the tracked object for consistency in detectors
-        for cp in contact_points:
-            if cp.body_b == tracked_object:
-                cp.body_a, cp.body_b = cp.body_b, cp.body_a
-        for ip in interference_points:
-            if ip.body_b == tracked_object:
-                ip.body_a, ip.body_b = ip.body_b, ip.body_a
-
-        return contact_points, interference_points
-
-    @staticmethod
-    def get_points_of_object(collisions: list[Collision], obj: Body) -> list[Collision]:
-        return [c for c in collisions if c.body_a == obj or c.body_b == obj]
-
-    @staticmethod
-    def get_points_of_body(collisions: list[Collision], body: Body) -> list[Collision]:
-        return [c for c in collisions if c.body_a == body or c.body_b == body]
-
-    @staticmethod
-    def get_bodies_in_contact(collisions: list[Collision]) -> list[Body]:
-        bodies = set()
-        for c in collisions:
-            bodies.add(c.body_a)
-            bodies.add(c.body_b)
-        return list(bodies)
+        return contact_bodies
 
     @abstractmethod
-    def trigger_events(self, contact_points: list[Collision], interference_points: list[Collision]) -> List[Event]:
+    def trigger_events(self, contact_bodies: list[Body]) -> List[Event]:
         """
         Checks if the detection condition is met, (e.g., the object is in contact with another object),
         and returns an object that represents the event.
@@ -435,7 +370,7 @@ class ContactDetector(AbstractContactDetector):
     A thread that detects if the object got into contact with another object.
     """
 
-    def trigger_events(self, contact_points: list[Collision], interference_points: list[Collision]) \
+    def trigger_events(self, contact_objects: list[Body]) \
             -> Union[List[ContactEvent], List[AgentContactEvent]]:
         """
         Check if the object got into contact with another object.
@@ -445,41 +380,18 @@ class ContactDetector(AbstractContactDetector):
         :return: An instance of the ContactEvent/AgentContactEvent class that represents the event if the object got
          into contact, else None.
         """
-        #logger.debug(f"ContactDetector: {contact_points=}, {interference_points=}")
-        prev_contacts = {
-            (cp.body_a, cp.body_b) for cp in self.latest_contact_points
-        }
-        curr_contacts = {(cp.body_a, cp.body_b) for cp in contact_points}
-
-        new_contact_pairs = curr_contacts - prev_contacts
-        new_objects_in_contact = [
-            cp.body_b
-            for cp in contact_points
-            if (cp.body_a, cp.body_b) in new_contact_pairs
-        ]
-
-        prev_interference = {c.body_b for c in self.latest_interference_points}
-        curr_interference = {c.body_b for c in interference_points}
-
-        new_bodies_in_interference = list(curr_interference - prev_interference)
+        #new_objects_in_contact = contact_objects.get_new_objects(self.latest_contact_points)
+        new_objects_in_contact = []
+        for obj in contact_objects:
+            if obj not in self.latest_contact_bodies:
+                new_objects_in_contact.append(obj)
 
         if self.with_object is not None:
-            new_objects_in_contact = [
-                obj for obj in new_objects_in_contact if obj == self.with_object
-            ]
-            new_bodies_in_interference = [
-                body for body in new_bodies_in_interference if body == self.with_object
-            ]
+            new_objects_in_contact = [obj for obj in new_objects_in_contact if obj == self.with_object]
 
-        events = self.get_events(
-            new_objects_contact=new_objects_in_contact,
-            new_bodies_interference=new_bodies_in_interference,
-            contact_points=contact_points,
-            interference_points=interference_points,
-            event_type=ContactEvent,
-        )
-
-        return events
+        if len(new_objects_in_contact) == 0:
+            return []
+        return self.get_events(new_objects_in_contact, contact_objects, ContactEvent)
 
 
 class LossOfContactDetector(AbstractContactDetector):
@@ -487,7 +399,7 @@ class LossOfContactDetector(AbstractContactDetector):
     A thread that detects if the object lost contact with another object.
     """
 
-    def trigger_events(self, contact_points: list[Collision], interference_points: list[Collision]) \
+    def trigger_events(self, contact_bodies: list[Body]) \
             -> List[LossOfContactEvent]:
         """
         Check if the object lost contact with another object.
@@ -497,47 +409,30 @@ class LossOfContactDetector(AbstractContactDetector):
         :return: An instance of the LossOfContactEvent/AgentLossOfContactEvent class that represents the event if the
          object lost contact, else None.
         """
-        #logger.debug(f"LossOfContactDetector: {contact_points=}, {interference_points=}")
-        objects_that_lost_contact, bodies_that_lost_interference = self.get_bodies_that_lost_contact(contact_points,
-                                                                                                     interference_points)
-        if len(objects_that_lost_contact) == 0 and len(bodies_that_lost_interference) == 0:
+        objects_that_lost_contact = self.get_bodies_that_lost_contact(contact_bodies)
+        if objects_that_lost_contact:
             return []
-        return self.get_events(objects_that_lost_contact, bodies_that_lost_interference,
-                               contact_points, interference_points, LossOfContactEvent)
+        return self.get_events(objects_that_lost_contact,
+                               contact_bodies, LossOfContactEvent)
 
-    def get_bodies_that_lost_contact(self, contact_points: list[Collision], interference_points: list[Collision]) \
-            -> Tuple[List[Body], List[Body]]:
+    def get_bodies_that_lost_contact(self, contact_bodies: list[Body]) -> List[Body]:
         """
-        Get the objects that lost contact or interference with the tracked object.
+        Get the objects that lost contact with the object to track.
+
+        :param contact_points: The current contact points.
+        :param interference_points: The current interference points.
+        :return: A list of Body instances that represent the objects that lost contact with the object to track.
         """
-        #logger.debug(f"LossOfContactDetector: {contact_points=}, {interference_points=}")
-        prev_contacts = {
-            (cp.body_a, cp.body_b) for cp in self.latest_contact_points
-        }
-        curr_contacts = {(cp.body_a, cp.body_b) for cp in contact_points}
-
-        lost_contact_pairs = prev_contacts - curr_contacts
-        objects_that_lost_contact = [
-            b for (a, b) in lost_contact_pairs if a == self.tracked_object
-        ]
-
-        prev_interference = {c.body_b for c in self.latest_interference_points}
-        curr_interference = {c.body_b for c in interference_points}
-
-        bodies_that_lost_interference = list(prev_interference - curr_interference)
+        objects_that_lost_contact = []
+        for body in contact_bodies:
+            if body not in self.latest_contact_bodies:
+                objects_that_lost_contact.append(body)
 
         if self.with_object is not None:
-            objects_that_lost_contact = [
-                obj for obj in objects_that_lost_contact if obj == self.with_object
-            ]
-            bodies_that_lost_interference = [
-                body
-                for body in bodies_that_lost_interference
-                if body == self.with_object
-            ]
+            objects_that_lost_contact = [obj for obj in objects_that_lost_contact
+                                         if obj == self.with_object]
 
-        return objects_that_lost_contact, bodies_that_lost_interference
-
+        return objects_that_lost_contact
 
 
 class MotionDetector(DetectorWithTrackedObject, ABC):
@@ -584,7 +479,7 @@ class MotionDetector(DetectorWithTrackedObject, ABC):
         """
         :param logger: An instance of the EventLogger class that is used to log the events.
         :param starter_event: An instance of the NewObjectEvent class that represents the event to start the event.
-        :param tracked_object: An optional Object instance that represents the object to track.
+        :param tracked_object: An optional Body instance that represents the object to track.
         :param velocity_threshold: The threshold for the velocity to detect movement.
         :param time_between_frames: The time between frames of episode player.
         :param window_size: The size of the window that is used to calculate the distances (must be > 1).
@@ -700,7 +595,6 @@ class MotionDetector(DetectorWithTrackedObject, ABC):
         Get the current pose and time of the object.
         """
         pose = self.tracked_object.global_pose.to_pose()
-
         return pose, time.time()  # pose.header.stamp.timestamp()
 
     def detect_events(self) -> Optional[List[MotionEvent]]:
@@ -711,22 +605,17 @@ class MotionDetector(DetectorWithTrackedObject, ABC):
         """
         try:
             # latest_pose, latest_time = self.update_with_latest_motion_data()
-            try:
-                _, _ = self.data_queue.get_nowait()
-                self.data_queue.task_done()
-            except Empty:
-                pass
-            
-            self.latest_pose, self.latest_time = self.get_current_pose_and_time()
-            self.poses.append(self.latest_pose)
-            self.times.append(self.latest_time)
+            _, _ = self.data_queue.get_nowait()
+            self.data_queue.task_done()
+            latest_pose, latest_time = self.get_current_pose_and_time()
+            self.poses.append(latest_pose)
+            self.times.append(latest_time)
             if len(self.poses) > 1:
                 self.calculate_and_update_latest_distance()
                 self._crop_distances_and_times_to_window_size()
 
             if not self.window_size_reached:
                 return
-
             events: Optional[List[MotionEvent]] = None
             if self.motion_sate_changed:
                 self.last_state_change_idx = len(self.all_distances) - 1
@@ -736,11 +625,8 @@ class MotionDetector(DetectorWithTrackedObject, ABC):
                 self.keep_track_of_history()
 
             return events
-        except Exception as e:
-            import traceback
-            traceback.print_exc()
-            self.exc = e
-            raise e
+        except Empty:
+            return
 
     def update_motion_state_and_create_event(self) -> MotionEvent:
         """
@@ -844,9 +730,7 @@ class MotionDetector(DetectorWithTrackedObject, ABC):
         """
         current_pose, current_time = self.get_current_pose_and_time()
         event_type = self.get_event_type()
-        start_pose_stamped = PoseStamped.from_spatial_type(self.start_pose)
-        current_pose_stamped = PoseStamped.from_spatial_type(current_pose)
-        event = event_type(self.tracked_object, start_pose_stamped, current_pose_stamped, timestamp=self.event_time)
+        event = event_type(self.tracked_object, self.start_pose, current_pose, timestamp=self.event_time)
         return event
 
     @abstractmethod
@@ -975,11 +859,8 @@ class RotationDetector(MotionDetector):
         """
         Calculate the angle between the latest and current quaternions of the object
         """
-        quat_1 = [float(self.poses[-2].orientation.x), float(self.poses[-2].orientation.y),
-                  float(self.poses[-2].orientation.z), float(self.poses[-2].orientation.w)]
-        quat_2 = [float(self.poses[-1].orientation.x), float(self.poses[-1].orientation.y),
-                  float(self.poses[-1].orientation.z), float(self.poses[-1].orientation.w)]
-        quat_diff = calculate_quaternion_difference(quat_1, quat_2)
+        quat_diff = calculate_quaternion_difference(self.poses[-2].to_quaternion().to_list(),
+                                                    self.poses[-1].to_quaternion().to_list())
         # angle = 2 * np.arccos(quat_diff[0])
         euler_diff = list(euler_from_quaternion(quat_diff))
         euler_diff[2] = 0

--- a/src/segmind/detectors/atomic_event_detectors.py
+++ b/src/segmind/detectors/atomic_event_detectors.py
@@ -25,10 +25,10 @@ except ImportError:
 from pycram.tf_transformations import euler_from_quaternion
 from typing_extensions import Optional, List, Union, Type, Tuple, Callable
 from ..event_logger import EventLogger
-from ..datastructures.events import Event, ContactEvent, LossOfContactEvent, AgentContactEvent, \
+from ..datastructures.events import Event, CloseContactEvent, LossOfCloseContactEvent, AgentContactEvent, \
     AgentLossOfContactEvent, TranslationEvent, StopTranslationEvent, NewObjectEvent, \
-    RotationEvent, StopRotationEvent, MotionEvent, AgentInterferenceEvent, InterferenceEvent, AbstractContactEvent, \
-    AgentLossOfInterferenceEvent, LossOfInterferenceEvent
+    RotationEvent, StopRotationEvent, MotionEvent, AgentInterferenceEvent, ContactEvent, AbstractContactEvent, \
+    AgentLossOfInterferenceEvent, LossOfContactEvent
 from .motion_detection_helpers import DataFilter
 from ..utils import calculate_quaternion_difference, \
     calculate_translation, PropagatingThread
@@ -290,21 +290,21 @@ class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
         DetectorWithTwoTrackedObjects.__init__(self, logger, tracked_object, with_object, wait_time,
                                                *args, **kwargs)
         self.max_closeness_distance = max_closeness_distance
-        self.latest_close_bodies: Optional[list[Body]]
-        self.latest_contact_bodies: Optional[list[Body]]
+        self.latest_close_bodies: Optional[list[Body]] = []
+        self.latest_contact_bodies: Optional[list[Body]] = []
 
     def get_events(self, new_objects_contact: list[Body], new_bodies_interference: list[Body],
                    close_bodies: list[Body], contact_bodies: list[Body],
                    event_type: Type[AbstractContactEvent]):
-        if event_type is ContactEvent:
-            contact_event_type = ContactEvent
+        if event_type is CloseContactEvent:
+            contact_event_type = CloseContactEvent
             agent_contact_event_type = AgentContactEvent
-            interference_event_type = InterferenceEvent
+            interference_event_type = ContactEvent
             agent_interference_event_type = AgentInterferenceEvent
-        elif event_type is LossOfContactEvent:
-            contact_event_type = LossOfContactEvent
+        elif event_type is LossOfCloseContactEvent:
+            contact_event_type = LossOfCloseContactEvent
             agent_contact_event_type = AgentLossOfContactEvent
-            interference_event_type = LossOfInterferenceEvent
+            interference_event_type = LossOfContactEvent
             agent_interference_event_type = AgentLossOfInterferenceEvent
         else:
             raise NotImplementedError(f"Invalid event type {event_type}")
@@ -314,7 +314,7 @@ class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
                 event_type = agent_interference_event_type
             else:
                 event_type = interference_event_type
-            events.append(event_type(close_bodies=close_bodies,
+            events.append(event_type(close_bodies=contact_bodies,
                                      latest_close_bodies=self.latest_close_bodies,
                                      of_object=self.tracked_object, with_object=body))
         for obj in new_objects_contact:
@@ -355,17 +355,20 @@ class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
         close_bodies = []
         contact_bodies = []
         if self.with_object:
-            if contact(self.tracked_object, self.with_object, self.max_closeness_distance):
-                close_bodies.append(self.with_object)
-            if contact(self.tracked_object, self.with_object, 0.0):
+            if contact(self.tracked_object, self.with_object):
                 contact_bodies.append(self.with_object)
+            if (contact(self.tracked_object, self.with_object, threshold=self.max_closeness_distance)
+                    and self.with_object not in contact_bodies):
+                close_bodies.append(self.with_object)
         else:
-            for obj in self.world.bodies_with_enabled_collision:
-                if contact(self.tracked_object, obj, self.max_closeness_distance):
-                    close_bodies.append(obj)
-                if contact(self.tracked_object, obj, 0.0):
+            for obj in self.tracked_object._world.bodies_with_enabled_collision:
+                if obj is self.tracked_object:
+                    continue
+                if contact(self.tracked_object, obj):
                     contact_bodies.append(obj)
-
+                if (contact(self.tracked_object, obj, threshold=self.max_closeness_distance)
+                        and obj not in contact_bodies):
+                    close_bodies.append(obj)
         return close_bodies, contact_bodies
 
     @abstractmethod
@@ -389,7 +392,7 @@ class ContactDetector(AbstractContactDetector):
     """
 
     def trigger_events(self, close_bodies: list[Body], contact_bodies: list[Body]) \
-            -> Union[List[ContactEvent], List[AgentContactEvent]]:
+            -> Union[List[CloseContactEvent], List[AgentContactEvent]]:
         """
         Check if the object got into contact with another object.
 
@@ -418,7 +421,7 @@ class ContactDetector(AbstractContactDetector):
         if len(new_close_objects) == 0 and len(new_contact_objects) == 0:
             return []
         return self.get_events(new_close_objects, new_contact_objects,
-                               close_bodies, contact_bodies, ContactEvent)
+                               close_bodies, contact_bodies, CloseContactEvent)
 
 
 class LossOfContactDetector(AbstractContactDetector):
@@ -427,7 +430,7 @@ class LossOfContactDetector(AbstractContactDetector):
     """
 
     def trigger_events(self, close_bodies: list[Body], contact_bodies: list[Body]) \
-            -> List[LossOfContactEvent]:
+            -> List[LossOfCloseContactEvent]:
         """
         Check if the object lost contact with another object.
 
@@ -441,7 +444,7 @@ class LossOfContactDetector(AbstractContactDetector):
         if len(objects_that_lost_contact) == 0 and len(bodies_that_lost_interference) == 0:
             return []
         return self.get_events(objects_that_lost_contact, bodies_that_lost_interference,
-                               close_bodies, contact_bodies, LossOfContactEvent)
+                               close_bodies, contact_bodies, LossOfCloseContactEvent)
 
     def get_bodies_that_lost_contact(self, close_bodies: list[Body], contact_bodies: list[Body]) \
             -> Tuple[List[Body], List[Body]]:

--- a/src/segmind/detectors/atomic_event_detectors.py
+++ b/src/segmind/detectors/atomic_event_detectors.py
@@ -6,6 +6,7 @@ from math import ceil
 from queue import Queue, Empty, Full
 
 import numpy as np
+from semantic_digital_twin.collision_checking.collision_detector import Collision
 from semantic_digital_twin.spatial_types.spatial_types import Pose
 from semantic_digital_twin.world import World
 from semantic_digital_twin.world_description.world_entity import Body, Agent
@@ -55,7 +56,7 @@ class AtomicEventDetector(PropagatingThread):
         self.episode_player: EpisodePlayer = episode_player
         self.fit_mode = fit_mode
         self.logger: EventLogger = logger if logger else EventLogger.current_logger
-        self.world: World = world if world else World.current_world
+        self.world: World = world
         self.wait_time = wait_time if wait_time is not None else timedelta(milliseconds=50)
 
         self.queues: List[Queue] = []
@@ -288,11 +289,11 @@ class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
         DetectorWithTwoTrackedObjects.__init__(self, logger, tracked_object, with_object, wait_time,
                                                *args, **kwargs)
         self.max_closeness_distance = max_closeness_distance
-        self.latest_contact_points: Optional[ContactPointsList] = ContactPointsList([])
-        self.latest_interference_points: Optional[ContactPointsList] = ContactPointsList([])
+        self.latest_contact_points: Optional[Collision] = Type[Collision]
+        self.latest_interference_points: Optional[Collision] = Type[Collision]
 
     def get_events(self, new_objects_contact: List[Body], new_bodies_interference: List[Body],
-                   contact_points: ContactPointsList, interference_points: ContactPointsList,
+                   contact_points: Collision, interference_points: Collision,
                    event_type: Type[AbstractContactEvent]):
         if event_type is ContactEvent:
             contact_event_type = ContactEvent
@@ -349,7 +350,7 @@ class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
 
         return events
 
-    def get_contact_points(self) -> Tuple[ContactPointsList, ContactPointsList]:
+    def get_contact_points(self) -> Tuple[Collision, Collision]:
         if self.with_object is not None:
             contact_points = self.tracked_object.closest_points_with_obj(self.with_object, self.max_closeness_distance)
             interference_points = self.tracked_object.get_contact_points_with_body(self.with_object)
@@ -359,7 +360,7 @@ class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
         return contact_points, interference_points
 
     @abstractmethod
-    def trigger_events(self, contact_points: ContactPointsList, interference_points: ContactPointsList) -> List[Event]:
+    def trigger_events(self, contact_points: Collision, interference_points: Collision) -> List[Event]:
         """
         Checks if the detection condition is met, (e.g., the object is in contact with another object),
         and returns an object that represents the event.
@@ -378,7 +379,7 @@ class ContactDetector(AbstractContactDetector):
     A thread that detects if the object got into contact with another object.
     """
 
-    def trigger_events(self, contact_points: ContactPointsList, interference_points: ContactPointsList) \
+    def trigger_events(self, contact_points: Collision, interference_points: Collision) \
             -> Union[List[ContactEvent], List[AgentContactEvent]]:
         """
         Check if the object got into contact with another object.
@@ -405,7 +406,7 @@ class LossOfContactDetector(AbstractContactDetector):
     A thread that detects if the object lost contact with another object.
     """
 
-    def trigger_events(self, contact_points: ContactPointsList, interference_points: ContactPointsList) \
+    def trigger_events(self, contact_points: Collision, interference_points: Collision) \
             -> List[LossOfContactEvent]:
         """
         Check if the object lost contact with another object.
@@ -422,7 +423,7 @@ class LossOfContactDetector(AbstractContactDetector):
         return self.get_events(objects_that_lost_contact, bodies_that_lost_interference,
                                contact_points, interference_points, LossOfContactEvent)
 
-    def get_bodies_that_lost_contact(self, contact_points: ContactPointsList, interference_points: ContactPointsList) \
+    def get_bodies_that_lost_contact(self, contact_points: Collision, interference_points: Collision) \
             -> Tuple[List[Body], List[Body]]:
         """
         Get the objects that lost contact with the object to track.
@@ -598,7 +599,7 @@ class MotionDetector(DetectorWithTrackedObject, ABC):
         """
         Get the current pose and time of the object.
         """
-        pose = self.tracked_object.pose
+        pose = self.tracked_object.global_pose.to_pose()
         return pose, time.time()  # pose.header.stamp.timestamp()
 
     def detect_events(self) -> Optional[List[MotionEvent]]:

--- a/src/segmind/detectors/atomic_event_detectors.py
+++ b/src/segmind/detectors/atomic_event_detectors.py
@@ -12,7 +12,8 @@ from semantic_digital_twin.reasoning.predicates import contact
 from semantic_digital_twin.spatial_types.spatial_types import Pose
 from semantic_digital_twin.world import World
 from semantic_digital_twin.world_description.world_entity import Body, Agent
-from ..datastructures.mixins import HasPrimaryTrackedObject,HasPrimaryAndSecondaryTrackedObjects
+from ..datastructures.mixins import HasPrimaryTrackedObject, HasSecondaryTrackedObject, \
+    HasPrimaryAndSecondaryTrackedObjects
 from ..detectors.motion_detection_helpers import is_displaced, is_stopped, \
     ExponentialMovingAverage
 from ..episode_player import EpisodePlayer
@@ -213,7 +214,7 @@ class NewObjectDetector(AtomicEventDetector):
         events = []
         try:
             while True:
-                event = NewObjectEvent(self.new_object_queue.get_nowait())
+                event = NewObjectEvent(self.new_object_queue.get_nowait(), tracked_object=self.tracked_object)
                 self.new_object_queue.task_done()
                 events.append(event)
         except queue.Empty:
@@ -243,7 +244,7 @@ class DetectorWithTrackedObject(AtomicEventDetector, HasPrimaryTrackedObject, AB
                  *args, **kwargs):
         """
         :param logger: An instance of the EventLogger class that is used to log the events.
-        :param tracked_object: An Body instance that represents the object to track.
+        :param tracked_object: An Object instance that represents the object to track.
         :param wait_time: An optional timedelta value that introduces a delay between calls to the event detector.
         """
         HasPrimaryTrackedObject.__init__(self, tracked_object=tracked_object)
@@ -262,8 +263,8 @@ class DetectorWithTwoTrackedObjects(AtomicEventDetector, HasPrimaryAndSecondaryT
                  wait_time: Optional[timedelta] = None, *args, **kwargs):
         """
         :param logger: An instance of the EventLogger class that is used to log the events.
-        :param tracked_object: An Body instance that represents the object to track.
-        :param with_object: An optional Body instance that represents the object to track.
+        :param tracked_object: An Object instance that represents the object to track.
+        :param with_object: An optional Object instance that represents the object to track.
         :param wait_time: An optional timedelta value that introduces a delay between calls to the event detector.
         """
         HasPrimaryAndSecondaryTrackedObjects.__init__(self, tracked_object=tracked_object, with_object=with_object)
@@ -289,32 +290,44 @@ class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
         DetectorWithTwoTrackedObjects.__init__(self, logger, tracked_object, with_object, wait_time,
                                                *args, **kwargs)
         self.max_closeness_distance = max_closeness_distance
+        self.latest_close_bodies: Optional[list[Body]]
         self.latest_contact_bodies: Optional[list[Body]]
-        self.latest_interference_bodies: Optional[list[Body]]
 
-    def get_events(self, new_objects_contact: List[Body], contact_bodies: list[Body], event_type: Type[AbstractContactEvent]):
+    def get_events(self, new_objects_contact: list[Body], new_bodies_interference: list[Body],
+                   close_bodies: list[Body], contact_bodies: list[Body],
+                   event_type: Type[AbstractContactEvent]):
         if event_type is ContactEvent:
             contact_event_type = ContactEvent
             agent_contact_event_type = AgentContactEvent
+            interference_event_type = InterferenceEvent
+            agent_interference_event_type = AgentInterferenceEvent
         elif event_type is LossOfContactEvent:
             contact_event_type = LossOfContactEvent
             agent_contact_event_type = AgentLossOfContactEvent
+            interference_event_type = LossOfInterferenceEvent
+            agent_interference_event_type = AgentLossOfInterferenceEvent
         else:
             raise NotImplementedError(f"Invalid event type {event_type}")
         events = []
-        for obj in new_objects_contact:
+        for body in new_bodies_interference:
             if issubclass(self.obj_type, Agent):
-                event_type = agent_contact_event_type
+                event_type = agent_interference_event_type
             else:
-                event_type = contact_event_type
-
-            contact_bodies = []
-            for i in self.world.bodies_with_enabled_collision:
-                if contact(obj, i):
-                    contact_bodies.append(i)
-            events.append(event_type(contact_points=contact_bodies,
-                                     latest_contact_points=self.latest_contact_bodies,
-                                     of_object=self.tracked_object, with_object=obj))
+                event_type = interference_event_type
+            events.append(event_type(close_bodies=close_bodies,
+                                     latest_close_bodies=self.latest_close_bodies,
+                                     of_object=self.tracked_object, with_object=body))
+        for obj in new_objects_contact:
+            if obj in new_bodies_interference:
+                continue
+            else:
+                if issubclass(self.obj_type, Agent):
+                    event_type = agent_contact_event_type
+                else:
+                    event_type = contact_event_type
+                events.append(event_type(close_bodies=close_bodies,
+                                         latest_close_bodies=self.latest_close_bodies,
+                                         of_object=self.tracked_object, with_object=obj))
         return events
 
     @property
@@ -329,29 +342,34 @@ class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
         Detects the closest points between the object to track and another object in the scene if the with_object
         attribute is set, else, between the object to track and all other objects in the scene.
         """
-        contact_bodies = self.get_contact_bodies()
+        close_bodies, contact_bodies = self.get_contact_bodies()
 
-        events = self.trigger_events(contact_bodies)
+        events = self.trigger_events(close_bodies, contact_bodies)
 
+        self.latest_close_bodies = close_bodies
         self.latest_contact_bodies = contact_bodies
 
         return events
 
-    def get_contact_bodies(self) -> list[Body]:
+    def get_contact_bodies(self) -> Tuple[list[Body], list[Body]]:
+        close_bodies = []
         contact_bodies = []
         if self.with_object:
-            if contact(self.tracked_object, self.with_object):
+            if contact(self.tracked_object, self.with_object, self.max_closeness_distance):
+                close_bodies.append(self.with_object)
+            if contact(self.tracked_object, self.with_object, 0.0):
                 contact_bodies.append(self.with_object)
-
         else:
             for obj in self.world.bodies_with_enabled_collision:
-                if contact(self.tracked_object, obj):
+                if contact(self.tracked_object, obj, self.max_closeness_distance):
+                    close_bodies.append(obj)
+                if contact(self.tracked_object, obj, 0.0):
                     contact_bodies.append(obj)
 
-        return contact_bodies
+        return close_bodies, contact_bodies
 
     @abstractmethod
-    def trigger_events(self, contact_bodies: list[Body]) -> List[Event]:
+    def trigger_events(self, close_bodies: list[Body], contact_bodies: list[Body]) -> List[Event]:
         """
         Checks if the detection condition is met, (e.g., the object is in contact with another object),
         and returns an object that represents the event.
@@ -370,7 +388,7 @@ class ContactDetector(AbstractContactDetector):
     A thread that detects if the object got into contact with another object.
     """
 
-    def trigger_events(self, contact_objects: list[Body]) \
+    def trigger_events(self, close_bodies: list[Body], contact_bodies: list[Body]) \
             -> Union[List[ContactEvent], List[AgentContactEvent]]:
         """
         Check if the object got into contact with another object.
@@ -380,18 +398,27 @@ class ContactDetector(AbstractContactDetector):
         :return: An instance of the ContactEvent/AgentContactEvent class that represents the event if the object got
          into contact, else None.
         """
-        #new_objects_in_contact = contact_objects.get_new_objects(self.latest_contact_points)
-        new_objects_in_contact = []
-        for obj in contact_objects:
-            if obj not in self.latest_contact_bodies:
-                new_objects_in_contact.append(obj)
+        new_close_objects = []
+        new_contact_objects = []
+        for body in close_bodies:
+            if body not in self.latest_close_bodies:
+                new_close_objects.append(body)
+
+        for body in contact_bodies:
+            #if body not in self.latest_contact_bodies and body not in new_close_objects:
+            if body not in self.latest_contact_bodies:
+                new_contact_objects.append(body)
+
+        #new_bodies_in_interference = contact_bodies.get_new_bodies(self.latest_interference_points)
 
         if self.with_object is not None:
-            new_objects_in_contact = [obj for obj in new_objects_in_contact if obj == self.with_object]
-
-        if len(new_objects_in_contact) == 0:
+            new_close_objects = [obj for obj in new_close_objects if obj == self.with_object]
+            new_contact_objects = [body for body in new_contact_objects if
+                                          body == self.with_object]
+        if len(new_close_objects) == 0 and len(new_contact_objects) == 0:
             return []
-        return self.get_events(new_objects_in_contact, contact_objects, ContactEvent)
+        return self.get_events(new_close_objects, new_contact_objects,
+                               close_bodies, contact_bodies, ContactEvent)
 
 
 class LossOfContactDetector(AbstractContactDetector):
@@ -399,7 +426,7 @@ class LossOfContactDetector(AbstractContactDetector):
     A thread that detects if the object lost contact with another object.
     """
 
-    def trigger_events(self, contact_bodies: list[Body]) \
+    def trigger_events(self, close_bodies: list[Body], contact_bodies: list[Body]) \
             -> List[LossOfContactEvent]:
         """
         Check if the object lost contact with another object.
@@ -409,30 +436,40 @@ class LossOfContactDetector(AbstractContactDetector):
         :return: An instance of the LossOfContactEvent/AgentLossOfContactEvent class that represents the event if the
          object lost contact, else None.
         """
-        objects_that_lost_contact = self.get_bodies_that_lost_contact(contact_bodies)
-        if objects_that_lost_contact:
+        objects_that_lost_contact, bodies_that_lost_interference = self.get_bodies_that_lost_contact(close_bodies,
+                                                                                                     contact_bodies)
+        if len(objects_that_lost_contact) == 0 and len(bodies_that_lost_interference) == 0:
             return []
-        return self.get_events(objects_that_lost_contact,
-                               contact_bodies, LossOfContactEvent)
+        return self.get_events(objects_that_lost_contact, bodies_that_lost_interference,
+                               close_bodies, contact_bodies, LossOfContactEvent)
 
-    def get_bodies_that_lost_contact(self, contact_bodies: list[Body]) -> List[Body]:
+    def get_bodies_that_lost_contact(self, close_bodies: list[Body], contact_bodies: list[Body]) \
+            -> Tuple[List[Body], List[Body]]:
         """
         Get the objects that lost contact with the object to track.
 
         :param contact_points: The current contact points.
         :param interference_points: The current interference points.
-        :return: A list of Body instances that represent the objects that lost contact with the object to track.
+        :return: A list of Object instances that represent the objects that lost contact with the object to track.
         """
+        objects_that_lost_closeness=[]
         objects_that_lost_contact = []
-        for body in contact_bodies:
-            if body not in self.latest_contact_bodies:
+        for body in self.latest_close_bodies:
+            if body not in close_bodies:
+                objects_that_lost_closeness.append(body)
+        for body in self.latest_contact_bodies:
+            if body not in contact_bodies:
                 objects_that_lost_contact.append(body)
 
+        #objects_that_lost_contact = close_bodies.get_objects_that_got_removed(self.latest_close_bodies)
+        #bodies_that_lost_interference = contact_bodies.get_bodies_that_got_removed(self.latest_contact_bodies)
         if self.with_object is not None:
-            objects_that_lost_contact = [obj for obj in objects_that_lost_contact
+            objects_that_lost_closeness = [obj for obj in objects_that_lost_closeness
                                          if obj == self.with_object]
+            objects_that_lost_contact = [body for body in objects_that_lost_contact
+                                             if body.parent_entity == self.with_object]
 
-        return objects_that_lost_contact
+        return objects_that_lost_closeness, objects_that_lost_contact
 
 
 class MotionDetector(DetectorWithTrackedObject, ABC):
@@ -479,7 +516,7 @@ class MotionDetector(DetectorWithTrackedObject, ABC):
         """
         :param logger: An instance of the EventLogger class that is used to log the events.
         :param starter_event: An instance of the NewObjectEvent class that represents the event to start the event.
-        :param tracked_object: An optional Body instance that represents the object to track.
+        :param tracked_object: An optional Object instance that represents the object to track.
         :param velocity_threshold: The threshold for the velocity to detect movement.
         :param time_between_frames: The time between frames of episode player.
         :param window_size: The size of the window that is used to calculate the distances (must be > 1).
@@ -488,7 +525,7 @@ class MotionDetector(DetectorWithTrackedObject, ABC):
         """
         DetectorWithTrackedObject.__init__(self, logger, tracked_object, *args, **kwargs)
         if self.episode_player is not None:
-            self.episode_player.add_frame_callback(self.update_with_latest_motion_data)
+            #self.episode_player.add_frame_callback(self.update_with_latest_motion_data)
             # self.time_between_frames = self.episode_player.time_between_frames
             self.time_between_frames: timedelta = time_between_frames
         else:

--- a/src/segmind/detectors/atomic_event_detectors.py
+++ b/src/segmind/detectors/atomic_event_detectors.py
@@ -6,6 +6,8 @@ from math import ceil
 from queue import Queue, Empty, Full
 
 import numpy as np
+
+from pycram.datastructures.pose import PoseStamped
 from semantic_digital_twin.collision_checking.collision_detector import Collision
 from semantic_digital_twin.spatial_types.spatial_types import Pose
 from semantic_digital_twin.world import World
@@ -134,7 +136,8 @@ class AtomicEventDetector(PropagatingThread):
         """
         events = self.detect_events()
         if events:
-            [self.log_event(event) for event in events]
+            for event in events:
+                self.log_event(event)
 
     def _wait_if_paused(self):
         """
@@ -595,11 +598,14 @@ class MotionDetector(DetectorWithTrackedObject, ABC):
                 except Empty:
                     pass
 
+        return latest_pose, latest_time
+
     def get_current_pose_and_time(self) -> Tuple[Pose, float]:
         """
         Get the current pose and time of the object.
         """
         pose = self.tracked_object.global_pose.to_pose()
+
         return pose, time.time()  # pose.header.stamp.timestamp()
 
     def detect_events(self) -> Optional[List[MotionEvent]]:
@@ -610,17 +616,22 @@ class MotionDetector(DetectorWithTrackedObject, ABC):
         """
         try:
             # latest_pose, latest_time = self.update_with_latest_motion_data()
-            _, _ = self.data_queue.get_nowait()
-            self.data_queue.task_done()
-            latest_pose, latest_time = self.get_current_pose_and_time()
-            self.poses.append(latest_pose)
-            self.times.append(latest_time)
+            try:
+                _, _ = self.data_queue.get_nowait()
+                self.data_queue.task_done()
+            except Empty:
+                pass
+            
+            self.latest_pose, self.latest_time = self.get_current_pose_and_time()
+            self.poses.append(self.latest_pose)
+            self.times.append(self.latest_time)
             if len(self.poses) > 1:
                 self.calculate_and_update_latest_distance()
                 self._crop_distances_and_times_to_window_size()
 
             if not self.window_size_reached:
                 return
+
             events: Optional[List[MotionEvent]] = None
             if self.motion_sate_changed:
                 self.last_state_change_idx = len(self.all_distances) - 1
@@ -630,8 +641,11 @@ class MotionDetector(DetectorWithTrackedObject, ABC):
                 self.keep_track_of_history()
 
             return events
-        except Empty:
-            return
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            self.exc = e
+            raise e
 
     def update_motion_state_and_create_event(self) -> MotionEvent:
         """
@@ -735,7 +749,9 @@ class MotionDetector(DetectorWithTrackedObject, ABC):
         """
         current_pose, current_time = self.get_current_pose_and_time()
         event_type = self.get_event_type()
-        event = event_type(self.tracked_object, self.start_pose, current_pose, timestamp=self.event_time)
+        start_pose_stamped = PoseStamped.from_spatial_type(self.start_pose)
+        current_pose_stamped = PoseStamped.from_spatial_type(current_pose)
+        event = event_type(self.tracked_object, start_pose_stamped, current_pose_stamped, timestamp=self.event_time)
         return event
 
     @abstractmethod
@@ -841,7 +857,9 @@ class TranslationDetector(MotionDetector):
         Calculate the Euclidean distance between the latest and current positions of the object.
         """
         # return calculate_euclidean_distance(self.latest_pose.position.to_list(), current_pose.position.to_list())
-        translation = calculate_translation(self.poses[-2].position.to_list(), self.poses[-1].position.to_list())
+        pos1 = [float(self.poses[-2].x), float(self.poses[-2].y), float(self.poses[-2].z)]
+        pos2 = [float(self.poses[-1].x), float(self.poses[-1].y), float(self.poses[-1].z)]
+        translation = calculate_translation(pos1, pos2)
         return translation
 
     def get_event_type(self):
@@ -862,8 +880,11 @@ class RotationDetector(MotionDetector):
         """
         Calculate the angle between the latest and current quaternions of the object
         """
-        quat_diff = calculate_quaternion_difference(self.poses[-2].orientation.to_list(),
-                                                    self.poses[-1].orientation.to_list())
+        quat_1 = [float(self.poses[-2].orientation.x), float(self.poses[-2].orientation.y),
+                  float(self.poses[-2].orientation.z), float(self.poses[-2].orientation.w)]
+        quat_2 = [float(self.poses[-1].orientation.x), float(self.poses[-1].orientation.y),
+                  float(self.poses[-1].orientation.z), float(self.poses[-1].orientation.w)]
+        quat_diff = calculate_quaternion_difference(quat_1, quat_2)
         # angle = 2 * np.arccos(quat_diff[0])
         euler_diff = list(euler_from_quaternion(quat_diff))
         euler_diff[2] = 0

--- a/src/segmind/detectors/atomic_event_detectors.py
+++ b/src/segmind/detectors/atomic_event_detectors.py
@@ -8,11 +8,13 @@ from queue import Queue, Empty, Full
 import numpy as np
 
 from pycram.datastructures.pose import PoseStamped
-from semantic_digital_twin.collision_checking.collision_detector import Collision
+from semantic_digital_twin.collision_checking.collision_detector import Collision, CollisionCheck
+from semantic_digital_twin.collision_checking.trimesh_collision_detector import TrimeshCollisionDetector
 from semantic_digital_twin.spatial_types.spatial_types import Pose
 from semantic_digital_twin.world import World
 from semantic_digital_twin.world_description.world_entity import Body, Agent
 
+from .. import logger, set_logger_level, LogLevel
 from ..datastructures.mixins import HasPrimaryTrackedObject, HasSecondaryTrackedObject, \
     HasPrimaryAndSecondaryTrackedObjects
 from ..detectors.motion_detection_helpers import is_displaced, is_stopped, \
@@ -34,7 +36,7 @@ from .motion_detection_helpers import DataFilter
 from ..utils import calculate_quaternion_difference, \
     calculate_translation, PropagatingThread
 
-
+set_logger_level(LogLevel.DEBUG)
 class AtomicEventDetector(PropagatingThread):
     """
     A thread that detects events in another thread and logs them. The event detector is a function that has no arguments
@@ -60,7 +62,7 @@ class AtomicEventDetector(PropagatingThread):
         self.logger: EventLogger = logger if logger else EventLogger.current_logger
         self.world: World = world
         self.wait_time = wait_time if wait_time is not None else timedelta(milliseconds=50)
-
+        self.tcd = TrimeshCollisionDetector(self.world)
         self.queues: List[Queue] = []
 
         self.run_once = False
@@ -198,7 +200,7 @@ class NewObjectDetector(AtomicEventDetector):
         self.new_object_queue: Queue[Body] = Queue()
         self.queues.append(self.new_object_queue)
         self.avoid_objects = avoid_objects if avoid_objects else lambda obj: False
-        self.world.add_callback_on_add_object(self.on_add_object)
+        #self.world.add_callback_on_add_object(self.on_add_object)
 
     def on_add_object(self, body: Body):
         """
@@ -292,11 +294,11 @@ class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
         DetectorWithTwoTrackedObjects.__init__(self, logger, tracked_object, with_object, wait_time,
                                                *args, **kwargs)
         self.max_closeness_distance = max_closeness_distance
-        self.latest_contact_points: Optional[Collision] = Type[Collision]
-        self.latest_interference_points: Optional[Collision] = Type[Collision]
+        self.latest_contact_points: List[Collision] = []
+        self.latest_interference_points: List[Collision] = []
 
     def get_events(self, new_objects_contact: List[Body], new_bodies_interference: List[Body],
-                   contact_points: Collision, interference_points: Collision,
+                   contact_points: list[Collision], interference_points: list[Collision],
                    event_type: Type[AbstractContactEvent]):
         if event_type is ContactEvent:
             contact_event_type = ContactEvent
@@ -316,18 +318,18 @@ class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
                 event_type = agent_interference_event_type
             else:
                 event_type = interference_event_type
-            events.append(event_type(contact_points=interference_points.get_points_of_body(body),
+            events.append(event_type(contact_points=self.get_points_of_body(interference_points, body),
                                      latest_contact_points=self.latest_interference_points,
                                      of_object=self.tracked_object, with_object=body))
         for obj in new_objects_contact:
-            if obj in new_bodies_interference or (len(obj.links) == 1 and obj.root_link in new_bodies_interference):
+            if obj in new_bodies_interference:
                 continue
             else:
                 if issubclass(self.obj_type, Agent):
                     event_type = agent_contact_event_type
                 else:
                     event_type = contact_event_type
-                events.append(event_type(contact_points=contact_points.get_points_of_object(obj),
+                events.append(event_type(contact_points=self.get_points_of_object(contact_points, obj),
                                          latest_contact_points=self.latest_contact_points,
                                          of_object=self.tracked_object, with_object=obj))
         return events
@@ -337,15 +339,16 @@ class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
         """
         The object type of the object to track.
         """
-        return self.tracked_object.ontology_concept
+        return self.tracked_object.__class__
 
     def detect_events(self) -> List[Event]:
         """
         Detects the closest points between the object to track and another object in the scene if the with_object
         attribute is set, else, between the object to track and all other objects in the scene.
         """
+        #logger.debug("Getting contact points...")
         contact_points, interference_points = self.get_contact_points()
-
+        #logger.debug(f"Contact points: {contact_points=}, {interference_points=}")
         events = self.trigger_events(contact_points, interference_points)
 
         self.latest_contact_points = contact_points
@@ -353,17 +356,67 @@ class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
 
         return events
 
-    def get_contact_points(self) -> Tuple[Collision, Collision]:
-        if self.with_object is not None:
-            contact_points = self.tracked_object.closest_points_with_obj(self.with_object, self.max_closeness_distance)
-            interference_points = self.tracked_object.get_contact_points_with_body(self.with_object)
+    def get_contact_points(self) -> Tuple[list[Collision], list[Collision]]:
+        return self.get_contact_points_for_body(self.tracked_object, self.max_closeness_distance, self.with_object)
+
+    @staticmethod
+    def get_contact_points_for_body(tracked_object: Body, max_closeness_distance: float,
+                                   with_object: Optional[Body] = None) -> Tuple[list[Collision], list[Collision]]:
+        world = tracked_object._world
+        collision_detector = TrimeshCollisionDetector(world)
+        collision_matrix = []
+        if with_object is not None:
+            try:
+                collision_matrix.append(
+                    CollisionCheck(tracked_object, with_object, max_closeness_distance, world))
+            except ValueError:
+                pass
         else:
-            contact_points = self.tracked_object.closest_points(self.max_closeness_distance)
-            interference_points = self.tracked_object.contact_points
+            for body in world.bodies_with_enabled_collision:
+                if body == tracked_object:
+                    continue
+                try:
+                    collision_matrix.append(
+                        CollisionCheck(tracked_object, body, max_closeness_distance, world))
+                except ValueError:
+                    continue
+
+        if not collision_matrix:
+            return [], []
+
+        logger.debug(f"Collision matrix: {collision_matrix=}")
+        all_collisions = collision_detector.check_collisions(collision_matrix)
+        contact_points = [c for c in all_collisions if c.contact_distance <= max_closeness_distance]
+        interference_points = [c for c in all_collisions if c.contact_distance <= 0]
+
+        # For contact/interference, body_a should always be the tracked object for consistency in detectors
+        for cp in contact_points:
+            if cp.body_b == tracked_object:
+                cp.body_a, cp.body_b = cp.body_b, cp.body_a
+        for ip in interference_points:
+            if ip.body_b == tracked_object:
+                ip.body_a, ip.body_b = ip.body_b, ip.body_a
+
         return contact_points, interference_points
 
+    @staticmethod
+    def get_points_of_object(collisions: list[Collision], obj: Body) -> list[Collision]:
+        return [c for c in collisions if c.body_a == obj or c.body_b == obj]
+
+    @staticmethod
+    def get_points_of_body(collisions: list[Collision], body: Body) -> list[Collision]:
+        return [c for c in collisions if c.body_a == body or c.body_b == body]
+
+    @staticmethod
+    def get_bodies_in_contact(collisions: list[Collision]) -> list[Body]:
+        bodies = set()
+        for c in collisions:
+            bodies.add(c.body_a)
+            bodies.add(c.body_b)
+        return list(bodies)
+
     @abstractmethod
-    def trigger_events(self, contact_points: Collision, interference_points: Collision) -> List[Event]:
+    def trigger_events(self, contact_points: list[Collision], interference_points: list[Collision]) -> List[Event]:
         """
         Checks if the detection condition is met, (e.g., the object is in contact with another object),
         and returns an object that represents the event.
@@ -382,7 +435,7 @@ class ContactDetector(AbstractContactDetector):
     A thread that detects if the object got into contact with another object.
     """
 
-    def trigger_events(self, contact_points: Collision, interference_points: Collision) \
+    def trigger_events(self, contact_points: list[Collision], interference_points: list[Collision]) \
             -> Union[List[ContactEvent], List[AgentContactEvent]]:
         """
         Check if the object got into contact with another object.
@@ -392,16 +445,41 @@ class ContactDetector(AbstractContactDetector):
         :return: An instance of the ContactEvent/AgentContactEvent class that represents the event if the object got
          into contact, else None.
         """
-        new_objects_in_contact = contact_points.get_new_objects(self.latest_contact_points)
-        new_bodies_in_interference = interference_points.get_new_bodies(self.latest_interference_points)
+        #logger.debug(f"ContactDetector: {contact_points=}, {interference_points=}")
+        prev_contacts = {
+            (cp.body_a, cp.body_b) for cp in self.latest_contact_points
+        }
+        curr_contacts = {(cp.body_a, cp.body_b) for cp in contact_points}
+
+        new_contact_pairs = curr_contacts - prev_contacts
+        new_objects_in_contact = [
+            cp.body_b
+            for cp in contact_points
+            if (cp.body_a, cp.body_b) in new_contact_pairs
+        ]
+
+        prev_interference = {c.body_b for c in self.latest_interference_points}
+        curr_interference = {c.body_b for c in interference_points}
+
+        new_bodies_in_interference = list(curr_interference - prev_interference)
+
         if self.with_object is not None:
-            new_objects_in_contact = [obj for obj in new_objects_in_contact if obj == self.with_object]
-            new_bodies_in_interference = [body for body in new_bodies_in_interference if
-                                          body.parent_entity == self.with_object]
-        if len(new_objects_in_contact) == 0 and len(new_bodies_in_interference) == 0:
-            return []
-        return self.get_events(new_objects_in_contact, new_bodies_in_interference,
-                               contact_points, interference_points, ContactEvent)
+            new_objects_in_contact = [
+                obj for obj in new_objects_in_contact if obj == self.with_object
+            ]
+            new_bodies_in_interference = [
+                body for body in new_bodies_in_interference if body == self.with_object
+            ]
+
+        events = self.get_events(
+            new_objects_contact=new_objects_in_contact,
+            new_bodies_interference=new_bodies_in_interference,
+            contact_points=contact_points,
+            interference_points=interference_points,
+            event_type=ContactEvent,
+        )
+
+        return events
 
 
 class LossOfContactDetector(AbstractContactDetector):
@@ -409,7 +487,7 @@ class LossOfContactDetector(AbstractContactDetector):
     A thread that detects if the object lost contact with another object.
     """
 
-    def trigger_events(self, contact_points: Collision, interference_points: Collision) \
+    def trigger_events(self, contact_points: list[Collision], interference_points: list[Collision]) \
             -> List[LossOfContactEvent]:
         """
         Check if the object lost contact with another object.
@@ -419,6 +497,7 @@ class LossOfContactDetector(AbstractContactDetector):
         :return: An instance of the LossOfContactEvent/AgentLossOfContactEvent class that represents the event if the
          object lost contact, else None.
         """
+        #logger.debug(f"LossOfContactDetector: {contact_points=}, {interference_points=}")
         objects_that_lost_contact, bodies_that_lost_interference = self.get_bodies_that_lost_contact(contact_points,
                                                                                                      interference_points)
         if len(objects_that_lost_contact) == 0 and len(bodies_that_lost_interference) == 0:
@@ -426,23 +505,39 @@ class LossOfContactDetector(AbstractContactDetector):
         return self.get_events(objects_that_lost_contact, bodies_that_lost_interference,
                                contact_points, interference_points, LossOfContactEvent)
 
-    def get_bodies_that_lost_contact(self, contact_points: Collision, interference_points: Collision) \
+    def get_bodies_that_lost_contact(self, contact_points: list[Collision], interference_points: list[Collision]) \
             -> Tuple[List[Body], List[Body]]:
         """
-        Get the objects that lost contact with the object to track.
-
-        :param contact_points: The current contact points.
-        :param interference_points: The current interference points.
-        :return: A list of Object instances that represent the objects that lost contact with the object to track.
+        Get the objects that lost contact or interference with the tracked object.
         """
-        objects_that_lost_contact = contact_points.get_objects_that_got_removed(self.latest_contact_points)
-        bodies_that_lost_interference = interference_points.get_bodies_that_got_removed(self.latest_interference_points)
+        #logger.debug(f"LossOfContactDetector: {contact_points=}, {interference_points=}")
+        prev_contacts = {
+            (cp.body_a, cp.body_b) for cp in self.latest_contact_points
+        }
+        curr_contacts = {(cp.body_a, cp.body_b) for cp in contact_points}
+
+        lost_contact_pairs = prev_contacts - curr_contacts
+        objects_that_lost_contact = [
+            b for (a, b) in lost_contact_pairs if a == self.tracked_object
+        ]
+
+        prev_interference = {c.body_b for c in self.latest_interference_points}
+        curr_interference = {c.body_b for c in interference_points}
+
+        bodies_that_lost_interference = list(prev_interference - curr_interference)
+
         if self.with_object is not None:
-            objects_that_lost_contact = [obj for obj in objects_that_lost_contact
-                                         if obj == self.with_object]
-            bodies_that_lost_interference = [body for body in bodies_that_lost_interference
-                                             if body.parent_entity == self.with_object]
+            objects_that_lost_contact = [
+                obj for obj in objects_that_lost_contact if obj == self.with_object
+            ]
+            bodies_that_lost_interference = [
+                body
+                for body in bodies_that_lost_interference
+                if body == self.with_object
+            ]
+
         return objects_that_lost_contact, bodies_that_lost_interference
+
 
 
 class MotionDetector(DetectorWithTrackedObject, ABC):

--- a/src/segmind/detectors/atomic_event_detectors.py
+++ b/src/segmind/detectors/atomic_event_detectors.py
@@ -6,6 +6,9 @@ from math import ceil
 from queue import Queue, Empty, Full
 
 import numpy as np
+from semantic_digital_twin.spatial_types.spatial_types import Pose
+from semantic_digital_twin.world import World
+from semantic_digital_twin.world_description.world_entity import Body, Agent
 
 from ..datastructures.mixins import HasPrimaryTrackedObject, HasSecondaryTrackedObject, \
     HasPrimaryAndSecondaryTrackedObjects
@@ -19,13 +22,6 @@ except ImportError:
     plt = None
 from pycram.tf_transformations import euler_from_quaternion
 from typing_extensions import Optional, List, Union, Type, Tuple, Callable
-
-from pycram.datastructures.world import World
-from pycram.datastructures.dataclasses import ContactPointsList
-from pycram.datastructures.pose import Pose
-from pycram.datastructures.world_entity import PhysicalBody
-from pycram.world_concepts.world_object import Object
-from pycrap.ontologies import PhysicalObject, Agent
 from ..event_logger import EventLogger
 from ..datastructures.events import Event, ContactEvent, LossOfContactEvent, AgentContactEvent, \
     AgentLossOfContactEvent, TranslationEvent, StopTranslationEvent, NewObjectEvent, \
@@ -188,24 +184,24 @@ class NewObjectDetector(AtomicEventDetector):
     """
 
     def __init__(self, logger: EventLogger, wait_time: Optional[timedelta] = None,
-                 avoid_objects: Optional[Callable[[Object], bool]] = None, *args, **kwargs):
+                 avoid_objects: Optional[Callable[[Body], bool]] = None, *args, **kwargs):
         """
         :param logger: An instance of the EventLogger class that is used to log the events.
         :param wait_time: An optional timedelta value that introduces a delay between calls to the event detector.
         :param avoid_objects: An optional list of strings that represent the names of the objects to avoid.
         """
         super().__init__(logger, wait_time, *args, **kwargs)
-        self.new_object_queue: Queue[Object] = Queue()
+        self.new_object_queue: Queue[Body] = Queue()
         self.queues.append(self.new_object_queue)
         self.avoid_objects = avoid_objects if avoid_objects else lambda obj: False
         self.world.add_callback_on_add_object(self.on_add_object)
 
-    def on_add_object(self, obj: Object):
+    def on_add_object(self, body: Body):
         """
         Callback function that is called when a new object is added to the scene.
         """
-        if not self.avoid_objects(obj):
-            self.new_object_queue.put(obj)
+        if not self.avoid_objects(body):
+            self.new_object_queue.put(body)
 
     def detect_events(self) -> List[Event]:
         """
@@ -242,7 +238,7 @@ class DetectorWithTrackedObject(AtomicEventDetector, HasPrimaryTrackedObject, AB
     A mixin class that provides one tracked object for the event detector.
     """
 
-    def __init__(self, logger: EventLogger, tracked_object: Object, wait_time: Optional[timedelta] = None,
+    def __init__(self, logger: EventLogger, tracked_object: Body, wait_time: Optional[timedelta] = None,
                  *args, **kwargs):
         """
         :param logger: An instance of the EventLogger class that is used to log the events.
@@ -261,7 +257,7 @@ class DetectorWithTwoTrackedObjects(AtomicEventDetector, HasPrimaryAndSecondaryT
     A mixin class that provides two tracked objects for the event detector.
     """
 
-    def __init__(self, logger: EventLogger, tracked_object: Object, with_object: Optional[Object] = None,
+    def __init__(self, logger: EventLogger, tracked_object: Body, with_object: Optional[Body] = None,
                  wait_time: Optional[timedelta] = None, *args, **kwargs):
         """
         :param logger: An instance of the EventLogger class that is used to log the events.
@@ -278,8 +274,8 @@ class DetectorWithTwoTrackedObjects(AtomicEventDetector, HasPrimaryAndSecondaryT
 
 
 class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
-    def __init__(self, logger: EventLogger, tracked_object: Object,
-                 with_object: Optional[Object] = None,
+    def __init__(self, logger: EventLogger, tracked_object: Body,
+                 with_object: Optional[Body] = None,
                  max_closeness_distance: Optional[float] = 0.05,
                  wait_time: Optional[timedelta] = timedelta(milliseconds=500),
                  *args, **kwargs):
@@ -295,7 +291,7 @@ class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
         self.latest_contact_points: Optional[ContactPointsList] = ContactPointsList([])
         self.latest_interference_points: Optional[ContactPointsList] = ContactPointsList([])
 
-    def get_events(self, new_objects_contact: List[Object], new_bodies_interference: List[Object],
+    def get_events(self, new_objects_contact: List[Body], new_bodies_interference: List[Body],
                    contact_points: ContactPointsList, interference_points: ContactPointsList,
                    event_type: Type[AbstractContactEvent]):
         if event_type is ContactEvent:
@@ -333,7 +329,7 @@ class AbstractContactDetector(DetectorWithTwoTrackedObjects, ABC):
         return events
 
     @property
-    def obj_type(self) -> Type[PhysicalObject]:
+    def obj_type(self) -> Type[Body]:
         """
         The object type of the object to track.
         """
@@ -479,7 +475,7 @@ class MotionDetector(DetectorWithTrackedObject, ABC):
     The threshold for the velocity to detect movement.
     """
 
-    def __init__(self, logger: EventLogger, tracked_object: Object,
+    def __init__(self, logger: EventLogger, tracked_object: Body,
                  velocity_threshold: Optional[float] = None,
                  time_between_frames: timedelta = timedelta(milliseconds=200),
                  window_size_in_seconds: int = 0.3,

--- a/src/segmind/detectors/atomic_event_detectors.py
+++ b/src/segmind/detectors/atomic_event_detectors.py
@@ -423,7 +423,7 @@ class LossOfContactDetector(AbstractContactDetector):
                                contact_points, interference_points, LossOfContactEvent)
 
     def get_bodies_that_lost_contact(self, contact_points: ContactPointsList, interference_points: ContactPointsList) \
-            -> Tuple[List[PhysicalBody], List[PhysicalBody]]:
+            -> Tuple[List[Body], List[Body]]:
         """
         Get the objects that lost contact with the object to track.
 

--- a/src/segmind/detectors/atomic_event_detectors.py
+++ b/src/segmind/detectors/atomic_event_detectors.py
@@ -7,7 +7,7 @@ from queue import Queue, Empty, Full
 
 import numpy as np
 
-from semantic_digital_twin.collision_checking.collision_detector import Collision
+from pycram.datastructures.pose import PoseStamped
 from semantic_digital_twin.reasoning.predicates import contact
 from semantic_digital_twin.spatial_types.spatial_types import Pose
 from semantic_digital_twin.world import World
@@ -605,11 +605,15 @@ class MotionDetector(DetectorWithTrackedObject, ABC):
         """
         try:
             # latest_pose, latest_time = self.update_with_latest_motion_data()
-            _, _ = self.data_queue.get_nowait()
-            self.data_queue.task_done()
-            latest_pose, latest_time = self.get_current_pose_and_time()
-            self.poses.append(latest_pose)
-            self.times.append(latest_time)
+            try:
+                _, _ = self.data_queue.get_nowait()
+                self.data_queue.task_done()
+            except Empty:
+                pass
+
+            self.latest_pose, self.latest_time = self.get_current_pose_and_time()
+            self.poses.append(self.latest_pose)
+            self.times.append(self.latest_time)
             if len(self.poses) > 1:
                 self.calculate_and_update_latest_distance()
                 self._crop_distances_and_times_to_window_size()
@@ -730,7 +734,9 @@ class MotionDetector(DetectorWithTrackedObject, ABC):
         """
         current_pose, current_time = self.get_current_pose_and_time()
         event_type = self.get_event_type()
-        event = event_type(self.tracked_object, self.start_pose, current_pose, timestamp=self.event_time)
+        start_pose_stamped = PoseStamped.from_spatial_type(self.start_pose)
+        current_pose_stamped = PoseStamped.from_spatial_type(current_pose)
+        event = event_type(self.tracked_object, start_pose_stamped, current_pose_stamped, timestamp=self.event_time)
         return event
 
     @abstractmethod

--- a/src/segmind/detectors/coarse_event_detectors.py
+++ b/src/segmind/detectors/coarse_event_detectors.py
@@ -336,7 +336,7 @@ class PlacingDetector(AbstractInteractionDetector):
 
     @classmethod
     @object_to_track_rdr.decorator
-    def get_object_to_track_from_starter_event(cls, starter_event: ContactEvent) -> Body:
+    def get_object_to_track_from_starter_event(cls, starter_event: CloseContactEvent) -> Body:
         pass
 
     @classmethod
@@ -389,7 +389,7 @@ def check_for_supporting_surface(tracked_object: Body,
     return supporting_surface
 
 
-def select_transportable_objects_from_contact_event(event: Union[ContactEvent, AgentContactEvent]) -> List[Body]:
+def select_transportable_objects_from_contact_event(event: Union[CloseContactEvent, AgentContactEvent]) -> List[Body]:
     """
     Select the objects that can be transported from the contact event.
 
@@ -399,7 +399,7 @@ def select_transportable_objects_from_contact_event(event: Union[ContactEvent, A
     return select_transportable_objects(contacted_objects + [event.tracked_object])
 
 
-def select_transportable_objects_from_loss_of_contact_event(event: LossOfContactEvent) -> List[Body]:
+def select_transportable_objects_from_loss_of_contact_event(event: LossOfCloseContactEvent) -> List[Body]:
     """
     Select the objects that can be transported from the loss of contact event.
     """

--- a/src/segmind/detectors/coarse_event_detectors.py
+++ b/src/segmind/detectors/coarse_event_detectors.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import os.path
 
+from pycram.designators.location_designator import Location
 from pycram.plan import Plan
-from pycram.designators.action_designator import PickUpAction, PlaceAction
-from pycrap.ontologies import Location, Supporter, Floor, Agent
-from ripple_down_rules.rdr_decorators import RDRDecorator
 
+from ripple_down_rules.rdr_decorators import RDRDecorator
+from semantic_digital_twin import world
+from semantic_digital_twin.semantic_annotations.semantic_annotations import Floor
 
 try:
     from matplotlib import pyplot as plt
@@ -15,8 +16,7 @@ except ImportError:
 
 from typing_extensions import Optional, List, Union, Dict
 
-from pycram.datastructures.world import UseProspectionWorld
-from pycram.ros import logdebug, loginfo
+
 from .atomic_event_detectors import *
 from ..datastructures.events import *
 from ..utils import get_angle_between_vectors, get_support, is_object_supported_by_container_body
@@ -74,7 +74,7 @@ class DetectorWithStarterEvent(AtomicEventDetector, ABC):
         self._start_timestamp = timestamp
 
     def _no_event_found_log(self, event_type: Type[Event]):
-        logdebug(f"{self} with starter event: {self.starter_event} found no event of type: {event_type}")
+        print(f"{self} with starter event: {self.starter_event} found no event of type: {event_type}")
 
 
 class DetectorWithTrackedObjectAndStarterEvent(DetectorWithStarterEvent, HasPrimaryTrackedObject, ABC):
@@ -82,7 +82,7 @@ class DetectorWithTrackedObjectAndStarterEvent(DetectorWithStarterEvent, HasPrim
     A type of event detector that requires an event to occur as a start condition and has one tracked object.
     """
 
-    currently_tracked_objects: Optional[Dict[Object, DetectorWithTrackedObjectAndStarterEvent]] = None
+    currently_tracked_objects: Optional[Dict[Body, DetectorWithTrackedObjectAndStarterEvent]] = None
     """
     All the objects that are currently tracked by a detector with a starter event.
     """
@@ -151,7 +151,7 @@ class DetectorWithTrackedObjectAndStarterEvent(DetectorWithStarterEvent, HasPrim
 
     @classmethod
     @abstractmethod
-    def get_object_to_track_from_starter_event(cls, starter_event: EventUnion) -> Object:
+    def get_object_to_track_from_starter_event(cls, starter_event: EventUnion) -> Body:
         """
         Get the object to track from the starter event.
 
@@ -198,7 +198,7 @@ class AbstractInteractionDetector(DetectorWithTrackedObjectAndStarterEvent, ABC)
             break
 
         if event:
-            loginfo(f"{self.__class__.__name__} detected an interaction with: {self.tracked_object.name}")
+            print(f"{self.__class__.__name__} detected an interaction with: {self.tracked_object.name}")
             return [event]
 
         return []
@@ -214,7 +214,7 @@ class AbstractInteractionDetector(DetectorWithTrackedObjectAndStarterEvent, ABC)
 
     @classmethod
     @abstractmethod
-    def get_object_to_track_from_starter_event(cls, starter_event: EventUnion) -> Object:
+    def get_object_to_track_from_starter_event(cls, starter_event: EventUnion) -> Body:
         """
         Get the object to track for interaction from the possible starter event.
 
@@ -233,7 +233,7 @@ class AbstractPickUpDetector(AbstractInteractionDetector, ABC):
     """
     An abstract detector that detects if the tracked_object was picked up.
     """
-    currently_tracked_objects: Dict[Object, AbstractPickUpDetector] = {}
+    currently_tracked_objects: Dict[Body, AbstractPickUpDetector] = {}
 
     @classmethod
     def action_type(cls):
@@ -255,7 +255,7 @@ class GeneralPickUpDetector(AbstractPickUpDetector):
     A decorator that uses a Ripple Down Rules model to check if the tracked_object was picked up and returns the PickUp Event.
     """
    
-    object_to_track_rdr: RDRDecorator = RDRDecorator(models_path, (Object, type(None)), True, package_name="segmind",
+    object_to_track_rdr: RDRDecorator = RDRDecorator(models_path, (Body, type(None)), True, package_name="segmind",
      fit=False, use_generated_classifier=False, fitting_decorator=EpisodePlayer.pause_resume)
     """
     A decorator that uses a Ripple Down Rules model to get the object to track from the starter event.
@@ -277,7 +277,7 @@ class GeneralPickUpDetector(AbstractPickUpDetector):
 
     @classmethod
     @object_to_track_rdr.decorator
-    def get_object_to_track_from_starter_event(cls, starter_event: EventUnion) -> Object:
+    def get_object_to_track_from_starter_event(cls, starter_event: EventUnion) -> Body:
         pass
 
     @classmethod
@@ -306,7 +306,7 @@ class PlacingDetector(AbstractInteractionDetector):
     A decorator that uses a Ripple Down Rules model to check if the tracked_object was picked up and returns the PickUp Event.
     """
    
-    object_to_track_rdr: RDRDecorator = RDRDecorator(models_path, (Object, type(None)), True, package_name="segmind",
+    object_to_track_rdr: RDRDecorator = RDRDecorator(models_path, (Body, type(None)), True, package_name="segmind",
      fit=False, use_generated_classifier=False, fitting_decorator=EpisodePlayer.pause_resume)
     """
     A decorator that uses a Ripple Down Rules model to get the object to track from the starter event.
@@ -336,7 +336,7 @@ class PlacingDetector(AbstractInteractionDetector):
 
     @classmethod
     @object_to_track_rdr.decorator
-    def get_object_to_track_from_starter_event(cls, starter_event: ContactEvent) -> Object:
+    def get_object_to_track_from_starter_event(cls, starter_event: ContactEvent) -> Body:
         pass
 
     @classmethod
@@ -350,8 +350,8 @@ class PlacingDetector(AbstractInteractionDetector):
         pass
 
 
-def check_for_supporting_surface(tracked_object: Object,
-                                 possible_surfaces: Optional[List[Object]] = None) -> Optional[Object]:
+def check_for_supporting_surface(tracked_object: Body,
+                                 possible_surfaces: Optional[List[Body]] = None) -> Optional[Body]:
     """
     Check if any of the possible surfaces are supporting the tracked_object.
 
@@ -359,7 +359,7 @@ def check_for_supporting_surface(tracked_object: Object,
     :param possible_surfaces: A list of Object instances that represent the possible surfaces.
     :return: An instance of the Object class that represents the supporting surface if found, else None.
     """
-    with UseProspectionWorld():
+    with world.World():
         dt = 0.07
         World.current_world.simulate(dt)
         prospection_obj = World.current_world.get_prospection_object_for_object(tracked_object)
@@ -385,11 +385,11 @@ def check_for_supporting_surface(tracked_object: Object,
             smallest_angle = angle
             supporting_surface = obj
     if supporting_surface is not None:
-        logdebug(f"found surface {supporting_surface.name}")
+        print(f"found surface {supporting_surface.name}")
     return supporting_surface
 
 
-def select_transportable_objects_from_contact_event(event: Union[ContactEvent, AgentContactEvent]) -> List[Object]:
+def select_transportable_objects_from_contact_event(event: Union[ContactEvent, AgentContactEvent]) -> List[Body]:
     """
     Select the objects that can be transported from the contact event.
 
@@ -399,21 +399,21 @@ def select_transportable_objects_from_contact_event(event: Union[ContactEvent, A
     return select_transportable_objects(contacted_objects + [event.tracked_object])
 
 
-def select_transportable_objects_from_loss_of_contact_event(event: LossOfContactEvent) -> List[Object]:
+def select_transportable_objects_from_loss_of_contact_event(event: LossOfContactEvent) -> List[Body]:
     """
     Select the objects that can be transported from the loss of contact event.
     """
     return select_transportable_objects([event.tracked_object])
 
 
-def select_transportable_objects(objects: List[Object], not_contained: bool = False) -> List[Object]:
+def select_transportable_objects(objects: List[Body], not_contained: bool = False) -> List[Body]:
     """
     Select the objects that can be transported
 
     :param objects: A list of Object instances.
     """
-    transportable_objects = [obj for obj in objects
-                             if not issubclass(obj.ontology_concept, (Agent, Location, Supporter, Floor))]
+    transportable_objects = [obj for obj in objects]
+    # Here check if this: not issubclass(obj.ontology_concept, (Agent, Location, Supporter, Floor))]
     if not_contained:
         transportable_objects = [obj for obj in transportable_objects
                                  if not is_object_supported_by_container_body(obj)]

--- a/src/segmind/detectors/models/coarse_event_detectors_general_pick_up_detector_start_condition_checker/general_pick_up_detector_start_condition_checker_output__scrdr.py
+++ b/src/segmind/detectors/models/coarse_event_detectors_general_pick_up_detector_start_condition_checker/general_pick_up_detector_start_condition_checker_output__scrdr.py
@@ -1,5 +1,7 @@
 from types import NoneType
-from ripple_down_rules.datastructures.case import create_case
+from typing import Dict
+
+from ripple_down_rules.datastructures.case import create_case, Case
 from typing_extensions import Optional
 from .general_pick_up_detector_start_condition_checker_output__scrdr_defs import *
 

--- a/src/segmind/detectors/models/coarse_event_detectors_general_pick_up_detector_start_condition_checker/general_pick_up_detector_start_condition_checker_output__scrdr_defs.py
+++ b/src/segmind/detectors/models/coarse_event_detectors_general_pick_up_detector_start_condition_checker/general_pick_up_detector_start_condition_checker_output__scrdr_defs.py
@@ -4,7 +4,7 @@ from segmind.episode_player import EpisodePlayer
 from segmind.utils import get_support
 from typing_extensions import Type
 
-from pycram.ros import logerr
+
 
 
 def conditions_313968436519149281932112885344716145224(case) -> bool:

--- a/src/segmind/detectors/spatial_relation_detector.py
+++ b/src/segmind/detectors/spatial_relation_detector.py
@@ -4,6 +4,8 @@ from os.path import dirname
 from queue import Queue, Empty
 
 from ripple_down_rules.rdr_decorators import RDRDecorator
+from segmind import logger, set_logger_level, LogLevel
+from semantic_digital_twin.reasoning.predicates import InsideOf
 from semantic_digital_twin.world_description.world_entity import Body
 from typing_extensions import Any, Dict, List, Optional, Type, Callable, Union
 
@@ -16,7 +18,7 @@ from ..datastructures.events import MotionEvent, EventUnion, StopMotionEvent, Ne
     LossOfSupportEvent, SupportEvent
 from ..datastructures.object_tracker import ObjectTrackerFactory
 from ..utils import get_support
-
+set_logger_level(LogLevel.DEBUG)
 EventCondition = Callable[[EventUnion], bool]
 
 
@@ -69,11 +71,11 @@ class SpatialRelationDetector(AtomicEventDetector):
             while True:
                 event = self.event_queue.get_nowait()
                 self.event_queue.task_done()
-                print(f"Checking event {event}")
+                logger.debug(f"Checking event {event}")
                 involved_bodies = event.involved_bodies
                 bodies_to_check = list(filter(lambda body: body not in checked_bodies, involved_bodies))
                 checked_bodies.extend(self.world.update_containment_for(bodies_to_check))
-                print(f"Checked bodies: {[body.name for body in checked_bodies]}")
+                logger.debug(f"Checked bodies: {[body.name for body in checked_bodies]}")
         except Empty:
             pass
 
@@ -91,10 +93,14 @@ class ContainmentDetector(SpatialRelationDetector):
         """
         Update the state of a body.
         """
-        if isinstance(body, Body):
-            for link in body.links.values():
-                self.bodies_states[link] = link.update_containment(intersection_ratio=0.6)
-        self.bodies_states[body] = body.update_containment(intersection_ratio=0.6)
+        for b in self.world.bodies:
+            if InsideOf(b, body) and b not in self.bodies_states:
+                self.bodies_states[b] = body
+
+        # if isinstance(body, Body):
+        #     for link in body.links.values():
+        #         self.bodies_states[link] = link.update_containment(intersection_ratio=0.6)
+        # self.bodies_states[body] = body.update_containment(intersection_ratio=0.6)
 
     def detect_events(self) -> None:
         """
@@ -156,7 +162,7 @@ class InsertionDetector(SpatialRelationDetector):
                 event: ContainmentEvent = self.event_queue.get_nowait()
                 self.event_queue.task_done()
                 if event.tracked_object in checked_bodies:
-                    print(f"tracked object {event.tracked_object.name} is already checked")
+                    logger.debug(f"tracked object {event.tracked_object.name} is already checked")
                     continue
                 while True:
                     latest_interference_with_hole = self.get_latest_interference_with_hole(event)

--- a/src/segmind/detectors/spatial_relation_detector.py
+++ b/src/segmind/detectors/spatial_relation_detector.py
@@ -1,13 +1,13 @@
 import time
+from abc import abstractmethod
 from os.path import dirname
 from queue import Queue, Empty
 
 from ripple_down_rules.rdr_decorators import RDRDecorator
+from semantic_digital_twin.world_description.world_entity import Body
 from typing_extensions import Any, Dict, List, Optional, Type, Callable, Union
 
-from pycram.datastructures.world_entity import abstractmethod, PhysicalBody
-from pycram.ros import logdebug, logerr
-from pycram.world_concepts.world_object import Object
+
 from segmind.datastructures.events import PlacingEvent
 from segmind.episode_player import EpisodePlayer
 from .atomic_event_detectors import AtomicEventDetector
@@ -31,7 +31,7 @@ class SpatialRelationDetector(AtomicEventDetector):
         self.event_queue: Queue[EventUnion] = Queue()
         self.queues.append(self.event_queue)
         self.check_on_events = check_on_events if check_on_events is not None else self.check_on_events
-        self.bodies_states: Dict[PhysicalBody, Any] = {}
+        self.bodies_states: Dict[Body, Any] = {}
         self.update_initial_state()
         for event, cond in self.check_on_events.items():
             self.logger.add_callback(event, self.on_event, cond)
@@ -46,7 +46,7 @@ class SpatialRelationDetector(AtomicEventDetector):
             self.update_body_state(body)
 
     @abstractmethod
-    def update_body_state(self, body: PhysicalBody):
+    def update_body_state(self, body: Body):
         """
         Update the state of a body.
         """
@@ -65,15 +65,15 @@ class SpatialRelationDetector(AtomicEventDetector):
         Detect spatial relations between objects.
         """
         try:
-            checked_bodies: List[PhysicalBody] = []
+            checked_bodies: List[Body] = []
             while True:
                 event = self.event_queue.get_nowait()
                 self.event_queue.task_done()
-                logdebug(f"Checking event {event}")
+                print(f"Checking event {event}")
                 involved_bodies = event.involved_bodies
                 bodies_to_check = list(filter(lambda body: body not in checked_bodies, involved_bodies))
                 checked_bodies.extend(self.world.update_containment_for(bodies_to_check))
-                logdebug(f"Checked bodies: {[body.name for body in checked_bodies]}")
+                print(f"Checked bodies: {[body.name for body in checked_bodies]}")
         except Empty:
             pass
 
@@ -87,11 +87,11 @@ class SpatialRelationDetector(AtomicEventDetector):
 class ContainmentDetector(SpatialRelationDetector):
     check_on_events = {PlacingEvent: None}
 
-    def update_body_state(self, body: PhysicalBody):
+    def update_body_state(self, body: Body):
         """
         Update the state of a body.
         """
-        if isinstance(body, Object):
+        if isinstance(body, Body):
             for link in body.links.values():
                 self.bodies_states[link] = link.update_containment(intersection_ratio=0.6)
         self.bodies_states[body] = body.update_containment(intersection_ratio=0.6)
@@ -143,7 +143,7 @@ class InsertionDetector(SpatialRelationDetector):
 
         return event.object_tracker.get_nearest_event_to_event_with_conditions(event, conditions)
 
-    def update_body_state(self, body: PhysicalBody):
+    def update_body_state(self, body: Body):
         ...
 
     def detect_events(self) -> None:
@@ -151,12 +151,12 @@ class InsertionDetector(SpatialRelationDetector):
         Detect Containment relations between objects.
         """
         try:
-            checked_bodies: List[PhysicalBody] = []
+            checked_bodies: List[Body] = []
             while True:
                 event: ContainmentEvent = self.event_queue.get_nowait()
                 self.event_queue.task_done()
                 if event.tracked_object in checked_bodies:
-                    logdebug(f"tracked object {event.tracked_object.name} is already checked")
+                    print(f"tracked object {event.tracked_object.name} is already checked")
                     continue
                 while True:
                     latest_interference_with_hole = self.get_latest_interference_with_hole(event)
@@ -194,7 +194,7 @@ class InsertionDetector(SpatialRelationDetector):
                                                ask_now=ask_now)
 
     @hole_insertion_verifier_rdr.decorator
-    def hole_insertion_verifier(self, hole: PhysicalBody, event: ContainmentEvent) -> bool:
+    def hole_insertion_verifier(self, hole: Body, event: ContainmentEvent) -> bool:
         pass
 
     @classmethod
@@ -210,7 +210,7 @@ class SupportDetector(SpatialRelationDetector):
 
     check_on_events = {StopTranslationEvent: None, LossOfInterferenceEvent: None}
 
-    def update_body_state(self, body: PhysicalBody, with_bodies: Optional[List[PhysicalBody]] = None):
+    def update_body_state(self, body: Body, with_bodies: Optional[List[Body]] = None):
         """
         Update the state of a body.
         """

--- a/src/segmind/detectors/spatial_relation_detector.py
+++ b/src/segmind/detectors/spatial_relation_detector.py
@@ -42,7 +42,7 @@ class SpatialRelationDetector(AtomicEventDetector):
         self.event_queue = Queue()
 
     def update_initial_state(self):
-        for body in self.world.objects:
+        for body in self.world.bodies:
             self.update_body_state(body)
 
     @abstractmethod

--- a/src/segmind/detectors/spatial_relation_detector.py
+++ b/src/segmind/detectors/spatial_relation_detector.py
@@ -14,7 +14,7 @@ from segmind.datastructures.events import PlacingEvent
 from segmind.episode_player import EpisodePlayer
 from .atomic_event_detectors import AtomicEventDetector
 from ..datastructures.events import MotionEvent, EventUnion, StopMotionEvent, NewObjectEvent, InsertionEvent, Event, \
-    ContainmentEvent, InterferenceEvent, LossOfInterferenceEvent, StopTranslationEvent, \
+    ContainmentEvent, ContactEvent, LossOfContactEvent, StopTranslationEvent, \
     LossOfSupportEvent, SupportEvent
 from ..datastructures.object_tracker import ObjectTrackerFactory
 from ..utils import get_support
@@ -137,13 +137,13 @@ class InsertionDetector(SpatialRelationDetector):
     check_on_events = {ContainmentEvent: event_condition}
 
     @staticmethod
-    def get_latest_interference_with_hole(event: ContainmentEvent) -> Optional[InterferenceEvent]:
+    def get_latest_interference_with_hole(event: ContainmentEvent) -> Optional[ContactEvent]:
         """
         Get the latest interference event with a hole before the given event.
         """
 
         def conditions(event_to_check: EventUnion) -> bool:
-            return (isinstance(event_to_check, InterferenceEvent) and
+            return (isinstance(event_to_check, ContactEvent) and
                     event_to_check.timestamp < event.timestamp and
                     "hole" in event_to_check.with_object.name)
 
@@ -214,7 +214,7 @@ class SupportDetector(SpatialRelationDetector):
     def event_condition(event: StopTranslationEvent) -> bool:
         return len(event.tracked_object.contact_points) > 0
 
-    check_on_events = {StopTranslationEvent: None, LossOfInterferenceEvent: None}
+    check_on_events = {StopTranslationEvent: None, LossOfContactEvent: None}
 
     def update_body_state(self, body: Body, with_bodies: Optional[List[Body]] = None):
         """

--- a/src/segmind/episode_player.py
+++ b/src/segmind/episode_player.py
@@ -6,9 +6,10 @@ from threading import RLock
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+
+from semantic_digital_twin.world import World
 from typing_extensions import Callable, Any, Optional, Dict, Generator
-from pycram.ros import logdebug
-from pycram.datastructures.world import World
+
 
 try:
     from pycram.worlds.multiverse import Multiverse
@@ -47,7 +48,7 @@ class EpisodePlayer(PropagatingThread, ABC):
             super().__init__()
             self.rdr_viewer: Optional[RDRCaseViewer] = rdr_viewer
             self.stop_after_ready: bool = stop_after_ready
-            self.world: World = world if world is not None else World.current_world
+            self.world: World = world if world is not None else World
             self._ready: bool = False
             self._status = PlayerStatus.CREATED
             self.time_between_frames: datetime.timedelta = time_between_frames if time_between_frames is not None else datetime.timedelta(seconds=0.01)
@@ -134,11 +135,11 @@ class EpisodePlayer(PropagatingThread, ABC):
         def wrapper(*args, **kwargs) -> Any:
             with cls.pause_resume_lock:
                 if cls._instance.status == PlayerStatus.PLAYING:
-                    logdebug("Pausing player")
+                    print("Pausing player")
                     cls._instance.pause()
                     result = func(*args, **kwargs)
                     cls._instance.resume()
-                    logdebug("Resuming player")
+                    print("Resuming player")
                     return result
                 else:
                     return func(*args, **kwargs)

--- a/src/segmind/episode_segmenter.py
+++ b/src/segmind/episode_segmenter.py
@@ -12,7 +12,6 @@ from .detectors.coarse_event_detectors import *
 from .detectors.spatial_relation_detector import SpatialRelationDetector
 from .episode_player import EpisodePlayer
 from .event_logger import EventLogger
-from .utils import check_if_object_is_supported, Imaginator
 set_logger_level(LogLevel.DEBUG)
 
 class EpisodeSegmenter(ABC):
@@ -144,7 +143,7 @@ class EpisodeSegmenter(ABC):
 
         while (not closed_threads) or (self.logger.event_queue.unfinished_tasks > 0):
             if (not self.episode_player.is_alive() or self.kill_event.is_set()) and not closed_threads:
-                time.sleep(5)
+                #time.sleep(5)
                 self.join_detectors(atomic_only=True)
                 closed_threads = True
 

--- a/src/segmind/episode_segmenter.py
+++ b/src/segmind/episode_segmenter.py
@@ -2,6 +2,8 @@ import datetime
 import threading
 from os.path import dirname
 
+from semantic_digital_twin.world_description.world_entity import Body
+from segmind import logger, set_logger_level, LogLevel
 from typing_extensions import List, Optional, Dict
 
 from .datastructures.events import *
@@ -11,7 +13,7 @@ from .detectors.spatial_relation_detector import SpatialRelationDetector
 from .episode_player import EpisodePlayer
 from .event_logger import EventLogger
 from .utils import check_if_object_is_supported, Imaginator
-
+set_logger_level(LogLevel.DEBUG)
 
 class EpisodeSegmenter(ABC):
 
@@ -105,13 +107,14 @@ class EpisodeSegmenter(ABC):
                                     if isinstance(detector, DetectorWithStarterEvent)]
         for detector_thread in atomic_detectors + non_atomic_detectors:
             detector_thread.stop()
-            print(f"Joining {detector_thread.thread_id}, {detector_thread.name}")
+            logger.debug(f"Joining {detector_thread.thread_id}, {detector_thread.name}")
             detector_thread.join()
 
     def start(self) -> None:
         """
         Start the episode player and the event detectors.
         """
+        logger.debug(f"Starting episode segmenter with detectors {self.detectors_to_start} and initial detectors {self.initial_detectors}.")
         self.start_episode_player_and_wait_till_ready()
         self.run_event_detectors()
 
@@ -123,9 +126,12 @@ class EpisodeSegmenter(ABC):
         Start the Episode player thread, and waits until the thread signals that it is
         ready (e.g., the replay environment is initialized with all objects in starting poses).
         """
+        logger.debug("Starting episode player thread.")
         if not self.episode_player.is_alive():
+            logger.debug("Episode player thread not alive, starting it.")
             self.episode_player.start()
         while not self.episode_player.ready:
+            logger.debug("Waiting for episode player thread to be ready.")
             time.sleep(0.1)
 
     def run_event_detectors(self) -> None:
@@ -206,7 +212,7 @@ class EpisodeSegmenter(ABC):
         """
         self.episode_player.pause()
         set_of_objects = set()
-        for obj in World.current_world.objects:
+        for obj in self.episode_player.world.bodies:
             if not self.avoid_object(obj):
                 set_of_objects.add(obj)
                 # if not check_if_object_is_supported(obj):
@@ -229,14 +235,14 @@ class EpisodeSegmenter(ABC):
         involved_objects = self.get_involved_bodies(event)
         if not involved_objects:
             return
-        print(f"Involved objects: {[obj.name for obj in involved_objects]}")
+        logger.debug(f"Involved objects: {[obj.name for obj in involved_objects]}")
         for obj in involved_objects:
             if self.avoid_object(obj):
                 continue
             if isinstance(obj, Body) and obj.parent_entity in self.object_trackers.keys():
                 continue
             if obj not in self.object_trackers.keys():
-                print(f"New object {obj.name}")
+                logger.debug(f"New object {obj.name}")
                 self.object_trackers[obj] = ObjectTracker(obj)
                 self.start_tracking_threads_for_new_object_and_event(obj, event)
 
@@ -251,7 +257,7 @@ class EpisodeSegmenter(ABC):
         """
         pass
 
-    def get_involved_bodies(self, event: EventUnion) -> List[Body]:
+    def get_involved_bodies(self, event: EventUnion) -> list[Body] | None:
         """
         Get the bodies involved in the event.
 
@@ -268,9 +274,11 @@ class EpisodeSegmenter(ABC):
         :param obj: The object to check.
         :return: True if the object should be avoided, False otherwise.
         """
-        return ((obj.is_an_environment or issubclass(obj.ontology_concept, (Supporter, Location)) or
-                 any([k in obj.name.lower() for k in self.objects_to_avoid])) or
-                (isinstance(obj, Body) and self.avoid_object(obj.parent_entity)))
+        logger.debug(f"Checking if object {obj.name} should be avoided.")
+        return not obj.has_collision()
+        #return ((obj.is_an_environment or issubclass(obj.ontology_concept, (Supporter, Location)) or
+        #         any([k in obj.name.lower() for k in self.objects_to_avoid])) or
+        #        (isinstance(obj, Body) and self.avoid_object(obj.parent_entity)))
 
     def start_motion_threads_for_object(self, obj: Body, event: Optional[NewObjectEvent] = None) -> None:
         """
@@ -304,7 +312,7 @@ class EpisodeSegmenter(ABC):
         """
         if not self.is_detector_redundant(detector_type, starter_event):
             if detector_type == PlacingDetector:
-                print(f"new placing detector for object {starter_event.tracked_object.name}")
+                logger.debug(f"new placing detector for object {starter_event.tracked_object.name}")
             self.create_detector_and_start_it(detector_type, starter_event=starter_event)
 
     @staticmethod
@@ -353,6 +361,7 @@ class EpisodeSegmenter(ABC):
         detector_kwargs = self.get_detector_args(detector_type, tracked_object=tracked_object,
                                                starter_event=starter_event, **detector_kwargs)
         detector_kwargs['episode_player'] = self.episode_player
+        detector_kwargs['world'] = self.episode_player.world
         detector_kwargs['logger'] = self.logger
         detector = detector_type(**detector_kwargs)
         self.starter_event_to_detector_thread_map[(starter_event, detector_type)] = detector
@@ -366,9 +375,9 @@ class EpisodeSegmenter(ABC):
         """
         detector.start()
         self.detector_threads_list.append(detector)
-        print(f"Created {type(detector).__name__}")
+        logger.debug(f"Created {type(detector).__name__}")
         if isinstance(detector, DetectorWithStarterEvent) and detector.starter_event is not None:
-            print(f"For starter event {detector.starter_event}")
+            logger.debug(f"For starter event {detector.starter_event}")
 
     @staticmethod
     def get_detector_args(detector_type: TypeEventDetectorUnion, tracked_object: Optional[Body] = None,
@@ -400,9 +409,9 @@ class EpisodeSegmenter(ABC):
         """
         Join all the threads.
         """
-        self.logger.print_events()
+        self.logger.logger.debug_events()
         self.logger.join()
-        print("All threads joined.")
+        logger.debug("All threads joined.")
 
 
 class AgentEpisodeSegmenter(EpisodeSegmenter):
@@ -412,7 +421,7 @@ class AgentEpisodeSegmenter(EpisodeSegmenter):
     """
 
     def start_tracking_threads_for_new_object_and_event(self, new_object: Body, event: Optional[ContactEvent] = None):
-        print(f"Creating contact and motion threads for object {new_object.name}")
+        logger.debug(f"Creating contact and motion threads for object {new_object.name}")
         self.start_contact_threads_for_object(new_object, event)
         self.start_motion_threads_for_object(new_object, event)
 

--- a/src/segmind/episode_segmenter.py
+++ b/src/segmind/episode_segmenter.py
@@ -4,7 +4,6 @@ from os.path import dirname
 
 from typing_extensions import List, Optional, Dict
 
-from pycram.ros import logerr
 from .datastructures.events import *
 from .datastructures.object_tracker import ObjectTracker
 from .detectors.coarse_event_detectors import *
@@ -42,7 +41,7 @@ class EpisodeSegmenter(ABC):
         self.objects_to_avoid = ['particle', 'floor', 'kitchen']
         self.starter_event_to_detector_thread_map: Dict[Tuple[Event, Type[DetectorWithStarterEvent]], DetectorWithStarterEvent] = {}
         self.detector_threads_list: List[EventDetectorUnion] = []
-        self.object_trackers: Dict[Object, ObjectTracker] = {}
+        self.object_trackers: Dict[Body, ObjectTracker] = {}
         self.plot_timeline = plot_timeline
         self.show_plots = show_plots
         self.plot_save_path = plot_save_path
@@ -106,7 +105,7 @@ class EpisodeSegmenter(ABC):
                                     if isinstance(detector, DetectorWithStarterEvent)]
         for detector_thread in atomic_detectors + non_atomic_detectors:
             detector_thread.stop()
-            logdebug(f"Joining {detector_thread.thread_id}, {detector_thread.name}")
+            print(f"Joining {detector_thread.thread_id}, {detector_thread.name}")
             detector_thread.join()
 
     def start(self) -> None:
@@ -230,19 +229,19 @@ class EpisodeSegmenter(ABC):
         involved_objects = self.get_involved_bodies(event)
         if not involved_objects:
             return
-        logdebug(f"Involved objects: {[obj.name for obj in involved_objects]}")
+        print(f"Involved objects: {[obj.name for obj in involved_objects]}")
         for obj in involved_objects:
             if self.avoid_object(obj):
                 continue
-            if isinstance(obj, Link) and obj.parent_entity in self.object_trackers.keys():
+            if isinstance(obj, Body) and obj.parent_entity in self.object_trackers.keys():
                 continue
             if obj not in self.object_trackers.keys():
-                logdebug(f"New object {obj.name}")
+                print(f"New object {obj.name}")
                 self.object_trackers[obj] = ObjectTracker(obj)
                 self.start_tracking_threads_for_new_object_and_event(obj, event)
 
     @abstractmethod
-    def start_tracking_threads_for_new_object_and_event(self, new_object: Object, event: EventUnion):
+    def start_tracking_threads_for_new_object_and_event(self, new_object: Body, event: EventUnion):
         """
         Start the tracking threads for the new object, these threads are used to track the object's motion or contacts
          for example.
@@ -252,7 +251,7 @@ class EpisodeSegmenter(ABC):
         """
         pass
 
-    def get_involved_bodies(self, event: EventUnion) -> List[PhysicalBody]:
+    def get_involved_bodies(self, event: EventUnion) -> List[Body]:
         """
         Get the bodies involved in the event.
 
@@ -262,7 +261,7 @@ class EpisodeSegmenter(ABC):
         if isinstance(event, EventWithTrackedObjects):
             return event.involved_bodies
 
-    def avoid_object(self, obj: Object) -> bool:
+    def avoid_object(self, obj: Body) -> bool:
         """
         Check if the object should be avoided.
 
@@ -271,9 +270,9 @@ class EpisodeSegmenter(ABC):
         """
         return ((obj.is_an_environment or issubclass(obj.ontology_concept, (Supporter, Location)) or
                  any([k in obj.name.lower() for k in self.objects_to_avoid])) or
-                (isinstance(obj, Link) and self.avoid_object(obj.parent_entity)))
+                (isinstance(obj, Body) and self.avoid_object(obj.parent_entity)))
 
-    def start_motion_threads_for_object(self, obj: Object, event: Optional[NewObjectEvent] = None) -> None:
+    def start_motion_threads_for_object(self, obj: Body, event: Optional[NewObjectEvent] = None) -> None:
         """
         Start the motion detection threads for the object.
 
@@ -284,7 +283,7 @@ class EpisodeSegmenter(ABC):
             self.create_detector_and_start_it(detector, tracked_object=obj, starter_event=event,
                                               time_between_frames=self.time_between_frames)
 
-    def start_contact_threads_for_object(self, obj: Object,
+    def start_contact_threads_for_object(self, obj: Body,
                                          event: Optional[ContactEvent] = None) -> None:
         """
         Start the contact threads for the object and updates the tracked objects.
@@ -305,7 +304,7 @@ class EpisodeSegmenter(ABC):
         """
         if not self.is_detector_redundant(detector_type, starter_event):
             if detector_type == PlacingDetector:
-                logdebug(f"new placing detector for object {starter_event.tracked_object.name}")
+                print(f"new placing detector for object {starter_event.tracked_object.name}")
             self.create_detector_and_start_it(detector_type, starter_event=starter_event)
 
     @staticmethod
@@ -339,7 +338,7 @@ class EpisodeSegmenter(ABC):
         return False
 
     def create_detector_and_start_it(self, detector_type: TypeEventDetectorUnion,
-                                     tracked_object: Optional[Object] = None,
+                                     tracked_object: Optional[Body] = None,
                                      starter_event: Optional[EventUnion] = None,
                                      *detector_args, **detector_kwargs) -> None:
         """
@@ -367,12 +366,12 @@ class EpisodeSegmenter(ABC):
         """
         detector.start()
         self.detector_threads_list.append(detector)
-        logdebug(f"Created {type(detector).__name__}")
+        print(f"Created {type(detector).__name__}")
         if isinstance(detector, DetectorWithStarterEvent) and detector.starter_event is not None:
-            logdebug(f"For starter event {detector.starter_event}")
+            print(f"For starter event {detector.starter_event}")
 
     @staticmethod
-    def get_detector_args(detector_type: TypeEventDetectorUnion, tracked_object: Optional[Object] = None,
+    def get_detector_args(detector_type: TypeEventDetectorUnion, tracked_object: Optional[Body] = None,
                           starter_event: Optional[EventUnion] = None, **other_detector_kwargs):
         """
         Get the detector arguments from the tracked object and/or the starter event.
@@ -403,7 +402,7 @@ class EpisodeSegmenter(ABC):
         """
         self.logger.print_events()
         self.logger.join()
-        logdebug("All threads joined.")
+        print("All threads joined.")
 
 
 class AgentEpisodeSegmenter(EpisodeSegmenter):
@@ -412,8 +411,8 @@ class AgentEpisodeSegmenter(EpisodeSegmenter):
      events that are relevant to the agent for example contact events of the hands or robot.
     """
 
-    def start_tracking_threads_for_new_object_and_event(self, new_object: Object, event: Optional[ContactEvent] = None):
-        logdebug(f"Creating contact and motion threads for object {new_object.name}")
+    def start_tracking_threads_for_new_object_and_event(self, new_object: Body, event: Optional[ContactEvent] = None):
+        print(f"Creating contact and motion threads for object {new_object.name}")
         self.start_contact_threads_for_object(new_object, event)
         self.start_motion_threads_for_object(new_object, event)
 
@@ -431,7 +430,7 @@ class AgentEpisodeSegmenter(EpisodeSegmenter):
             self.start_contact_threads_for_object(agent)
 
     @staticmethod
-    def get_agents() -> List[Object]:
+    def get_agents() -> List[Body]:
         """
         :return: A list of Object instances that represent the available agents in the world.
         """
@@ -444,10 +443,10 @@ class NoAgentEpisodeSegmenter(EpisodeSegmenter):
      events that are relevant to the objects in the world with the lack of an agent in the episode.
     """
 
-    def start_tracking_threads_for_new_object_and_event(self, new_object: Object, event: EventUnion):
+    def start_tracking_threads_for_new_object_and_event(self, new_object: Body, event: EventUnion):
         pass
 
-    def get_involved_bodies(self, event: EventUnion) -> List[Object]:
+    def get_involved_bodies(self, event: EventUnion) -> List[Body]:
         return []
 
     def _process_event(self, event: EventUnion) -> None:

--- a/src/segmind/episode_segmenter.py
+++ b/src/segmind/episode_segmenter.py
@@ -291,7 +291,7 @@ class EpisodeSegmenter(ABC):
                                               time_between_frames=self.time_between_frames)
 
     def start_contact_threads_for_object(self, obj: Body,
-                                         event: Optional[ContactEvent] = None) -> None:
+                                         event: Optional[CloseContactEvent] = None) -> None:
         """
         Start the contact threads for the object and updates the tracked objects.
 
@@ -321,7 +321,7 @@ class EpisodeSegmenter(ABC):
         self_ = case_dict['self_']
         output_ = case_dict['output_']
         if issubclass(detector_type, GeneralPickUpDetector):
-            if isinstance(starter_event, LossOfContactEvent):
+            if isinstance(starter_event, LossOfCloseContactEvent):
                 pick_up_detectors = [detector for (_, _), detector in self_.starter_event_to_detector_thread_map.items()
                                      if isinstance(detector, GeneralPickUpDetector)]
                 if len(pick_up_detectors) > 0 and not output_:
@@ -408,7 +408,7 @@ class EpisodeSegmenter(ABC):
         """
         Join all the threads.
         """
-        self.logger.logger.debug_events()
+        #self.logger.debug_events()
         self.logger.join()
         logger.debug("All threads joined.")
 
@@ -419,13 +419,13 @@ class AgentEpisodeSegmenter(EpisodeSegmenter):
      events that are relevant to the agent for example contact events of the hands or robot.
     """
 
-    def start_tracking_threads_for_new_object_and_event(self, new_object: Body, event: Optional[ContactEvent] = None):
+    def start_tracking_threads_for_new_object_and_event(self, new_object: Body, event: Optional[CloseContactEvent] = None):
         logger.debug(f"Creating contact and motion threads for object {new_object.name}")
         self.start_contact_threads_for_object(new_object, event)
         self.start_motion_threads_for_object(new_object, event)
 
     def _process_event(self, event: Event) -> None:
-        if isinstance(event, ContactEvent):
+        if isinstance(event, CloseContactEvent):
             self.update_tracked_objects(event)
 
     def _run_initial_event_detectors(self) -> None:

--- a/src/segmind/event_logger.py
+++ b/src/segmind/event_logger.py
@@ -3,21 +3,18 @@ from __future__ import annotations
 import os
 import queue
 import threading
-from collections import UserDict
+from collections import UserDict, defaultdict
 from threading import RLock
 import time
 from datetime import timedelta
 from os.path import dirname, abspath
 import re
 
-from owlready2_optimized import defaultdict
+from semantic_digital_twin.world_description.world_entity import Body
 from typing_extensions import List, Optional, Dict, Type, TYPE_CHECKING, Callable, Tuple
 
 from pycram.datastructures.dataclasses import TextAnnotation
 from pycram.datastructures.enums import WorldMode
-from pycram.datastructures.world import World
-from pycram.ros import loginfo, logdebug, logerr
-from pycram.world_concepts.world_object import Object, Link
 from .datastructures.events import Event, EventUnion, EventWithTrackedObjects, EventWithTwoTrackedObjects, PickUpEvent, \
     InsertionEvent
 from .datastructures.mixins import HasPrimaryTrackedObject
@@ -128,7 +125,7 @@ class EventLogger:
         """
         # logdebug(f"Logging event: {event}")
         if self.events_to_annotate is not None and (type(event) in self.events_to_annotate):
-            loginfo(f"Logging event: {event}")
+            print(f"Logging event: {event}")
             if self.annotation_thread is not None:
                 self.annotation_queue.put(event)
                 
@@ -176,7 +173,7 @@ class EventLogger:
         save_path to the save path you prefer).
         :param save_path: the html plot will be save the given path, if not provided, it will not be saved.
         """
-        loginfo("Plotting events:")
+        print("Plotting events:")
         # construct a dataframe with the events
         import pandas as pd
         import plotly.express as px
@@ -193,22 +190,22 @@ class EventLogger:
                 data_dict['event'].append(event.__class__.__name__)
                 obj = event.tracked_object if isinstance(event, HasPrimaryTrackedObject) else tracker.obj
                 data_dict['object'].append(obj.name)
-                if isinstance(obj, Object):
+                if isinstance(obj, Body):
                     data_dict['obj_type'].append(obj.obj_type.name)
-                elif isinstance(obj, Link):
+                elif isinstance(obj, Body):
                     data_dict['obj_type'].append(f'Link of {obj.parent_entity.obj_type}')
                 if isinstance(event, EventWithTwoTrackedObjects) and event.with_object is not None:
                     with_object = event.with_object
                     data_dict['with_object'].append(with_object.name)
-                    if isinstance(with_object, Object):
+                    if isinstance(with_object, Body):
                         data_dict['with_obj_type'].append(with_object.obj_type.name)
-                    elif isinstance(with_object, Link):
+                    elif isinstance(with_object, Body):
                         data_dict['with_obj_type'].append(f'Link of {with_object.parent_entity.obj_type}')
                 else:
                     data_dict['with_object'].append(None)
                     data_dict['with_obj_type'].append(None)
         if len(data_dict['start']) == 0:
-            loginfo("No events to plot.")
+            print("No events to plot.")
             return
         # subtract the start time from all timestamps
         min_start = min(data_dict['start'])
@@ -262,14 +259,14 @@ class EventLogger:
                 save_path += '.html'
             file_path = abspath(save_path)
             fig.write_html(file_path)
-            loginfo(f"Plot saved to {file_path}")
+            print(f"Plot saved to {file_path}")
 
     def print_events(self):
         """
         Print all events that have been logged.
         """
-        loginfo("Events:")
-        loginfo(self.__str__())
+        print("Events:")
+        print(self.__str__())
 
     def get_events_per_thread(self) -> Dict[str, List[Event]]:
         """
@@ -287,7 +284,7 @@ class EventLogger:
             events = self.timeline.copy()
         return events
 
-    def get_latest_event_of_detector_for_object(self, detector_prefix: str, obj: Object) -> Optional[Event]:
+    def get_latest_event_of_detector_for_object(self, detector_prefix: str, obj: Body) -> Optional[Event]:
         """
         Get the latest of event of the thread that has the given prefix and object name in its id.
 
@@ -297,7 +294,7 @@ class EventLogger:
         thread_id = self.find_thread_with_prefix_and_object(detector_prefix, obj.name)
         return self.get_latest_event_of_thread(thread_id)
 
-    def get_nearest_event_of_detector_for_object(self, detector_prefix: str, obj: Object,
+    def get_nearest_event_of_detector_for_object(self, detector_prefix: str, obj: Body,
                                                  timestamp: float) -> Optional[EventUnion]:
         """
         Get the nearest event of the thread that has the given prefix and object name in its id.
@@ -368,7 +365,7 @@ class EventLogger:
             self.annotation_thread.join()
             while self.annotation_queue.unfinished_tasks > 0:
                 event = self.annotation_queue.get_nowait()
-                logdebug(f"Left out annotation for event: {event}")
+                print(f"Left out annotation for event: {event}")
                 self.annotation_queue.task_done()
             self.annotation_queue.join()
         self.event_queue.join()
@@ -405,7 +402,7 @@ class EventAnnotationThread(threading.Thread):
                     text_to_speech(f"The {obj_name_map[event.tracked_object.name]} was inserted into the {hole_name}")
                 event.annotate()
             except Exception as e:
-                logerr(f"Error annotating event {event}: {e}")
+                print(f"Error annotating event {event}: {e}")
                 continue
 
     def stop(self):

--- a/src/segmind/event_logger.py
+++ b/src/segmind/event_logger.py
@@ -12,9 +12,6 @@ import re
 
 from semantic_digital_twin.world_description.world_entity import Body
 from typing_extensions import List, Optional, Dict, Type, TYPE_CHECKING, Callable, Tuple
-
-from pycram.datastructures.dataclasses import TextAnnotation
-from pycram.datastructures.enums import WorldMode
 from .datastructures.events import Event, EventUnion, EventWithTrackedObjects, EventWithTwoTrackedObjects, PickUpEvent, \
     InsertionEvent
 from .datastructures.mixins import HasPrimaryTrackedObject
@@ -378,7 +375,7 @@ class EventAnnotationThread(threading.Thread):
     def __init__(self, logger: EventLogger):
         super().__init__()
         self.logger = logger
-        self.current_annotations: List[TextAnnotation] = []
+        #self.current_annotations: List[TextAnnotation] = []
         self.kill_event = threading.Event()
 
     def run(self):

--- a/src/segmind/players/cram_player.py
+++ b/src/segmind/players/cram_player.py
@@ -14,7 +14,7 @@ from pycram.designator import ObjectDesignatorDescription
 from pycram.language import SequentialPlan
 
 from pycram.plan import Plan
-from pycram.process_module import ProcessModule, simulated_robot
+#from pycram.process_module import ProcessModule, simulated_robot
 
 
 from ..episode_player import EpisodePlayer

--- a/src/segmind/players/cram_player.py
+++ b/src/segmind/players/cram_player.py
@@ -2,21 +2,21 @@ import threading
 import time
 from datetime import timedelta
 
+from pycram.robot_plans import PickUpActionDescription, MoveTorsoActionDescription
+from semantic_digital_twin.datastructures.joint_state import TorsoState
+from semantic_digital_twin.world import World
 from typing_extensions import Optional
 
-from pycram.datastructures.enums import Arms, Grasp, TorsoState, PlanStatus
+from pycram.datastructures.enums import Arms, Grasp
 from pycram.datastructures.grasp import GraspDescription
 from pycram.designator import ObjectDesignatorDescription
-from pycram.designators.action_designator import PickUpActionDescription, MoveTorsoActionDescription
+
 from pycram.language import SequentialPlan
-from pycram.datastructures.pose import Pose
-from pycram.datastructures.world import World
+
 from pycram.plan import Plan
 from pycram.process_module import ProcessModule, simulated_robot
-from pycram.ros import logdebug
-from pycram.worlds.bullet_world import BulletWorld
-from pycrap.ontologies import Robot, Kitchen
-from pycram.world_concepts.world_object import Object
+
+
 from ..episode_player import EpisodePlayer
 
 
@@ -42,15 +42,14 @@ class CRAMPlayer(EpisodePlayer):
         """
         self.world = world if world else World.current_world
         if not self.world:
-            self.world = BulletWorld()
+            self.world = World()
     
     def _pause(self):
-        logdebug("Pausing Plan")
-        Plan.status = PlanStatus.PAUSED
+        print("Pausing Plan")
+
 
     def _resume(self):
-        logdebug("Resuming Plan")
-        Plan.status = PlanStatus.RUNNING
+        print("Resuming Plan")
 
     def _run(self):
         self.ready = True

--- a/src/segmind/players/csv_player.py
+++ b/src/segmind/players/csv_player.py
@@ -55,4 +55,5 @@ class CSVEpisodePlayer(FilePlayer):
             else:
                 obj = self.world.get_body_by_name(obj_name)
                 objects_poses[obj] = obj.global_pose.to_pose()
+
         return objects_poses

--- a/src/segmind/players/csv_player.py
+++ b/src/segmind/players/csv_player.py
@@ -6,16 +6,17 @@ from semantic_digital_twin.spatial_types import HomogeneousTransformationMatrix
 from semantic_digital_twin.spatial_types.spatial_types import Pose, Vector3, Quaternion
 from semantic_digital_twin.world_description.world_entity import Body
 from typing_extensions import Dict, Set
-
+from segmind import logger, set_logger_level, LogLevel
 from pycram.datastructures.pose import PoseStamped, Header
 from .data_player import FilePlayer, FrameData
 
-
+set_logger_level(LogLevel.DEBUG)
 class CSVEpisodePlayer(FilePlayer):
     data_frames: pd.DataFrame
     data_object_names: Set[str]
 
     def get_frame_data_generator(self):
+        logger.debug(f"Reading CSV file {self.file_path}")
         self.data_frames = pd.read_csv(self.file_path)
         self.data_object_names = {v.split(':')[0] for v in self.data_frames.columns if ':' in v}
         for i, (frame_id, objects_data) in enumerate(self.data_frames.iterrows()):

--- a/src/segmind/players/csv_player.py
+++ b/src/segmind/players/csv_player.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 
 import pandas as pd
+from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
+from semantic_digital_twin.spatial_types import HomogeneousTransformationMatrix
 from semantic_digital_twin.spatial_types.spatial_types import Pose, Vector3, Quaternion
 from semantic_digital_twin.world_description.world_entity import Body
 from typing_extensions import Dict, Set
@@ -36,16 +38,20 @@ class CSVEpisodePlayer(FilePlayer):
             obj_position = [objects_data[f"{obj_name}:position_{i}"] for i in range(3)]
             obj_orientation = [objects_data[f"{obj_name}:quaternion_{i}"] for i in range(4)]
             obj_orientation[0], obj_orientation[3] = obj_orientation[3], obj_orientation[0]
-            obj_pose = PoseStamped(Pose(Vector3(*obj_position), Quaternion(*obj_orientation)),
-                                   Header(stamp=datetime.fromtimestamp(current_time)))
+            obj_pose = HomogeneousTransformationMatrix.from_xyz_rpy(x=obj_position[0], y=obj_position[1], z=obj_position[2],
+                                                                    roll=obj_orientation[1], pitch=obj_orientation[2], yaw=obj_orientation[3])
+
             if self.position_shift is not None:
-                obj_pose.position += self.position_shift
-            obj_type = Body
+                obj_pose.x += self.position_shift.x
+                obj_pose.y += self.position_shift.y
+                obj_pose.z += self.position_shift.z
+
+
 
             # Create the object if it does not exist in the world and set its pose
-            if obj_name not in self.world.get_object_names():
-                obj = Body(obj_name, obj_type, pose=obj_pose, path=f"{obj_name}.urdf")
+            if obj_name not in self.world.bodies:
+                obj = Body(name=PrefixedName(str(obj_name)))
             else:
-                obj = self.world.get_object_by_name(obj_name)
-                objects_poses[obj] = obj_pose
+                obj = self.world.get_body_by_name(obj_name)
+                objects_poses[obj] = obj.global_pose.to_pose()
         return objects_poses

--- a/src/segmind/players/csv_player.py
+++ b/src/segmind/players/csv_player.py
@@ -1,11 +1,11 @@
 from datetime import datetime
 
 import pandas as pd
+from semantic_digital_twin.spatial_types.spatial_types import Pose, Vector3, Quaternion
+from semantic_digital_twin.world_description.world_entity import Body
 from typing_extensions import Dict, Set
 
-from pycram.datastructures.pose import Pose, PoseStamped, Vector3, Quaternion, Header
-from pycram.world_concepts.world_object import Object
-from pycrap.ontologies import PhysicalObject
+from pycram.datastructures.pose import PoseStamped, Header
 from .data_player import FilePlayer, FrameData
 
 
@@ -28,8 +28,8 @@ class CSVEpisodePlayer(FilePlayer):
     def _resume(self):
         ...
 
-    def get_objects_poses(self, frame_data: FrameData) -> Dict[Object, Pose]:
-        objects_poses: Dict[Object, Pose] = {}
+    def get_objects_poses(self, frame_data: FrameData) -> Dict[Body, Pose]:
+        objects_poses: Dict[Body, Pose] = {}
         objects_data = frame_data.objects_data
         current_time = frame_data.time
         for obj_name in self.data_object_names:
@@ -40,11 +40,11 @@ class CSVEpisodePlayer(FilePlayer):
                                    Header(stamp=datetime.fromtimestamp(current_time)))
             if self.position_shift is not None:
                 obj_pose.position += self.position_shift
-            obj_type = PhysicalObject
+            obj_type = Body
 
             # Create the object if it does not exist in the world and set its pose
             if obj_name not in self.world.get_object_names():
-                obj = Object(obj_name, obj_type, pose=obj_pose, path=f"{obj_name}.urdf")
+                obj = Body(obj_name, obj_type, pose=obj_pose, path=f"{obj_name}.urdf")
             else:
                 obj = self.world.get_object_by_name(obj_name)
                 objects_poses[obj] = obj_pose

--- a/src/segmind/players/csv_player.py
+++ b/src/segmind/players/csv_player.py
@@ -42,18 +42,12 @@ class CSVEpisodePlayer(FilePlayer):
             obj_pose = HomogeneousTransformationMatrix.from_xyz_rpy(x=obj_position[0], y=obj_position[1], z=obj_position[2],
                                                                     roll=obj_orientation[1], pitch=obj_orientation[2], yaw=obj_orientation[3])
 
-            if self.position_shift is not None:
+
+            if self.position_shift:
                 obj_pose.x += self.position_shift.x
                 obj_pose.y += self.position_shift.y
                 obj_pose.z += self.position_shift.z
 
-
-
-            # Create the object if it does not exist in the world and set its pose
-            if obj_name not in self.world.bodies:
-                obj = Body(name=PrefixedName(str(obj_name)))
-            else:
-                obj = self.world.get_body_by_name(obj_name)
-                objects_poses[obj] = obj.global_pose.to_pose()
-
+            obj = self.world.get_body_by_name(obj_name)
+            objects_poses[obj] = obj_pose.to_pose()
         return objects_poses

--- a/src/segmind/players/data_player.py
+++ b/src/segmind/players/data_player.py
@@ -136,11 +136,14 @@ class DataPlayer(EpisodePlayer, ABC):
 
         :param frame_data: The frame data.
         """
+        print(f"Processing frame data{frame_data}")
         objects_poses = self.get_objects_poses(frame_data)
+        print(objects_poses)
         joint_states = self.get_joint_states(frame_data)
+        print(joint_states)
         if len(objects_poses):
-            if self.sync_robot_only:
-                objects_poses = {self.world.robot: objects_poses[self.world.robot]}
+            #if self.sync_robot_only:
+            #    objects_poses = {self.world.robot: objects_poses[self.world.robot]}
             for obj in self.world.bodies:
                 # check in the dictionary if obj is the key and set its pose accordingly
                 if obj in objects_poses:

--- a/src/segmind/players/data_player.py
+++ b/src/segmind/players/data_player.py
@@ -10,9 +10,7 @@ from threading import RLock
 
 from typing_extensions import Callable, Optional, Dict, Generator, List
 
-from pycram.datastructures.pose import Pose, Vector3
-from pycram.datastructures.world import World
-from pycram.world_concepts.world_object import Object
+
 
 try:
     from pycram.worlds.multiverse import Multiverse

--- a/src/segmind/players/data_player.py
+++ b/src/segmind/players/data_player.py
@@ -10,7 +10,10 @@ from threading import RLock
 
 from typing_extensions import Callable, Optional, Dict, Generator, List
 
-
+from semantic_digital_twin.spatial_types import Vector3
+from semantic_digital_twin.spatial_types.spatial_types import Pose
+from semantic_digital_twin.world import World
+from semantic_digital_twin.world_description.world_entity import Body
 
 try:
     from pycram.worlds.multiverse import Multiverse
@@ -143,7 +146,7 @@ class DataPlayer(EpisodePlayer, ABC):
             self.world.robot.set_multiple_joint_positions(joint_states)
 
     @abstractmethod
-    def get_objects_poses(self, frame_data: FrameData) -> Dict[Object, Pose]:
+    def get_objects_poses(self, frame_data: FrameData) -> Dict[Body, Pose]:
         """
         Get the poses of the objects.
 
@@ -188,4 +191,4 @@ class FilePlayer(DataPlayer, ABC):
         Copy the model files to the world data directory.
         """
         # Copy the entire folder and its contents
-        shutil.copytree(self.models_dir, self.world.conf.cache_dir + "/objects", dirs_exist_ok=True)
+        #shutil.copytree(self.models_dir, self.world.conf.cache_dir + "/objects", dirs_exist_ok=True)

--- a/src/segmind/players/data_player.py
+++ b/src/segmind/players/data_player.py
@@ -11,7 +11,7 @@ from threading import RLock
 from typing_extensions import Callable, Optional, Dict, Generator, List
 
 from semantic_digital_twin.spatial_types import Vector3
-from semantic_digital_twin.spatial_types.spatial_types import Pose
+from semantic_digital_twin.spatial_types.spatial_types import Pose, HomogeneousTransformationMatrix
 from semantic_digital_twin.world import World
 from semantic_digital_twin.world_description.world_entity import Body
 
@@ -141,7 +141,21 @@ class DataPlayer(EpisodePlayer, ABC):
         if len(objects_poses):
             if self.sync_robot_only:
                 objects_poses = {self.world.robot: objects_poses[self.world.robot]}
-            self.world.reset_multiple_objects_base_poses(objects_poses)
+            for obj in self.world.bodies:
+                # check in the dictionary if obj is the key and set its pose accordingly
+                if obj in objects_poses:
+                    with self.world.modify_world():
+                        new_pose = type(obj.parent_connection)(
+                            parent=obj.parent_connection.parent,
+                            child=obj,
+                            parent_T_connection_expression= HomogeneousTransformationMatrix.from_xyz_rpy(
+                                x=objects_poses[obj].x, y=objects_poses[obj].y, z=objects_poses[obj].z,
+                                roll=objects_poses[obj].to_quaternion().x, pitch=objects_poses[obj].to_quaternion().y,
+                                yaw=objects_poses[obj].to_quaternion().z,
+                            )
+                        )
+                        self.world.add_connection(new_pose)
+            #self.world.reset_multiple_objects_base_poses(objects_poses)
         if len(joint_states):
             self.world.robot.set_multiple_joint_positions(joint_states)
 

--- a/src/segmind/players/data_player.py
+++ b/src/segmind/players/data_player.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from threading import RLock
 
 from typing_extensions import Callable, Optional, Dict, Generator, List
-
+from semantic_digital_twin.world_description.connections import FixedConnection
 from semantic_digital_twin.spatial_types import Vector3
 from semantic_digital_twin.spatial_types.spatial_types import Pose, HomogeneousTransformationMatrix
 from semantic_digital_twin.world import World
@@ -138,9 +138,7 @@ class DataPlayer(EpisodePlayer, ABC):
         """
         print(f"Processing frame data{frame_data}")
         objects_poses = self.get_objects_poses(frame_data)
-        print(objects_poses)
         joint_states = self.get_joint_states(frame_data)
-        print(joint_states)
         if len(objects_poses):
             #if self.sync_robot_only:
             #    objects_poses = {self.world.robot: objects_poses[self.world.robot]}
@@ -148,14 +146,19 @@ class DataPlayer(EpisodePlayer, ABC):
                 # check in the dictionary if obj is the key and set its pose accordingly
                 if obj in objects_poses:
                     with self.world.modify_world():
-                        new_pose = type(obj.parent_connection)(
+                        new_pose = FixedConnection(
                             parent=obj.parent_connection.parent,
                             child=obj,
-                            parent_T_connection_expression= HomogeneousTransformationMatrix.from_xyz_rpy(
-                                x=objects_poses[obj].x, y=objects_poses[obj].y, z=objects_poses[obj].z,
-                                roll=objects_poses[obj].to_quaternion().x, pitch=objects_poses[obj].to_quaternion().y,
-                                yaw=objects_poses[obj].to_quaternion().z,
+                            parent_T_connection_expression=HomogeneousTransformationMatrix.from_xyz_rpy(
+                                x=objects_poses[obj].x, y=objects_poses[obj].y, z=objects_poses[obj].z
                             )
+                            # parent=obj.parent_connection.parent,
+                            # child=obj,
+                            # = HomogeneousTransformationMatrix.from_xyz_rpy(
+                            #     x=objects_poses[obj].x, y=objects_poses[obj].y, z=objects_poses[obj].z,
+                            #     roll=objects_poses[obj].to_quaternion().x, pitch=objects_poses[obj].to_quaternion().y,
+                            #     yaw=objects_poses[obj].to_quaternion().z,
+                            # )
                         )
                         self.world.add_connection(new_pose)
             #self.world.reset_multiple_objects_base_poses(objects_poses)

--- a/src/segmind/players/json_player.py
+++ b/src/segmind/players/json_player.py
@@ -9,13 +9,13 @@ import scipy
 import trimesh
 from pycram.tf_transformations import euler_matrix, quaternion_from_matrix, quaternion_matrix, quaternion_from_euler, \
     euler_from_quaternion
+from semantic_digital_twin.spatial_types.spatial_types import Pose
+from semantic_digital_twin.world import World
+from semantic_digital_twin.world_description.world_entity import Body
 from trimesh import Geometry, Trimesh
 from typing_extensions import Type, List, Tuple, Union, Dict, Optional
 
-from pycram.datastructures.world import TransformStamped, World
-from pycram.datastructures.pose import Header, PoseStamped, Vector3, Quaternion, Pose, Transform
-from pycram.world_concepts.world_object import Object
-from pycrap.ontologies import PhysicalObject
+from pycram.datastructures.pose import Header, PoseStamped, Transform
 from ..episode_player import EpisodePlayer
 from .data_player import FilePlayer, FrameData
 from ..utils import calculate_quaternion_difference
@@ -27,7 +27,7 @@ class JSONPlayer(FilePlayer):
                  time_between_frames: datetime.timedelta = datetime.timedelta(milliseconds=50),
                  objects_to_ignore: Optional[List[int]] = None,
                  obj_id_to_name: Optional[Dict[int, str]] = None,
-                 obj_id_to_type: Optional[Dict[int, Type[PhysicalObject]]] = None):
+                 obj_id_to_type: Optional[Dict[int, Type[Body]]] = None):
         """
         Initializes the FAMEEpisodePlayer with the specified json file and scene id.
 
@@ -78,8 +78,8 @@ class JSONPlayer(FilePlayer):
     def _resume(self):
         ...
 
-    def get_objects_poses(self, frame_data: FrameData) -> Dict[Object, Pose]:
-        objects_poses: Dict[Object, Pose] = {}
+    def get_objects_poses(self, frame_data: FrameData) -> Dict[Body, Pose]:
+        objects_poses: Dict[Body, Pose] = {}
         objects_data = frame_data.objects_data
         for object_id, object_poses_data in objects_data.items():
 
@@ -104,7 +104,7 @@ class JSONPlayer(FilePlayer):
                 objects_poses[obj] = self.apply_orientation_correction_to_object_pose(obj, pose)
         return objects_poses
 
-    def apply_orientation_correction_to_object_pose(self, obj: Object, obj_pose: PoseStamped) -> Pose:
+    def apply_orientation_correction_to_object_pose(self, obj: Body, obj_pose: PoseStamped) -> Pose:
         """
         Correct the orientation of an object based on the orientation of the mesh, and return the corrected pose.
 
@@ -128,7 +128,7 @@ class JSONPlayer(FilePlayer):
         u, s, vh = np.linalg.svd(mean_rotation)
         return np.dot(u, vh)
 
-    def estimate_object_mesh_orientation(self, obj: Object) -> np.ndarray:
+    def estimate_object_mesh_orientation(self, obj: Body) -> np.ndarray:
         """
         Estimate the rotation of an object based on the orientation of a plane that is fitted to the base of the mesh
          of the object.
@@ -143,7 +143,7 @@ class JSONPlayer(FilePlayer):
         homogeneous_matrix[:3, :3] = rotation_matrix
         return quaternion_from_matrix(homogeneous_matrix)
 
-    def get_base_points_of_object(self, obj: Object, transform_points: bool = True) -> np.ndarray:
+    def get_base_points_of_object(self, obj: Body, transform_points: bool = True) -> np.ndarray:
         """
         Get the base points of an object.
 
@@ -157,7 +157,7 @@ class JSONPlayer(FilePlayer):
             base_points = np.dot(base_points, quaternion_matrix(obj.get_orientation.to_list())[:3, :3].T)
         return base_points
 
-    def get_relative_base_origin_of_object(self, obj: Object) -> np.ndarray:
+    def get_relative_base_origin_of_object(self, obj: Body) -> np.ndarray:
         """
         Get the origin of the base of the object relative to the origin of the object.
 
@@ -170,7 +170,7 @@ class JSONPlayer(FilePlayer):
         base_origin[2] = min_z
         return base_origin
 
-    def get_mesh_of_object(self, obj: Object, apply_scale: bool = True,
+    def get_mesh_of_object(self, obj: Body, apply_scale: bool = True,
                            apply_transform: bool = True) -> Trimesh:
         """
         Get the mesh of an object.
@@ -183,7 +183,7 @@ W
         return self.object_meshes.get(obj,
                                       self.load_scale_and_transform_mesh_of_object(obj, apply_scale, apply_transform))
 
-    def load_scale_and_transform_mesh_of_object(self, obj: Object, apply_scale: bool = True,
+    def load_scale_and_transform_mesh_of_object(self, obj: Body, apply_scale: bool = True,
                                                 apply_transform: bool = True) -> Geometry:
         """
         Load, scale and transform the mesh of an object.
@@ -303,11 +303,11 @@ W
         else:
             return f"object_{object_id}"
 
-    def get_object_type(self, object_id: int) -> Type[PhysicalObject]:
+    def get_object_type(self, object_id: int) -> Type[Body]:
         if self.obj_id_to_type is not None and object_id in self.obj_id_to_type:
             return self.obj_id_to_type[int(object_id)]
         else:
-            return PhysicalObject
+            return Body
 
     @staticmethod
     def get_mesh_name(object_id: str) -> str:

--- a/src/segmind/segmenters/cram_segmenter.py
+++ b/src/segmind/segmenters/cram_segmenter.py
@@ -1,8 +1,8 @@
+from pycram.robot_plans import ActionDescription
 from typing_extensions import Type, List, Optional
 from queue import Queue
 
-from pycram.designator import ActionDescription
-from pycram.plan import Plan, ResolvedActionNode
+from pycram.plan import Plan, ActionNode
 from ..episode_segmenter import AgentEpisodeSegmenter
 from ..players.cram_player import CRAMPlayer
 
@@ -42,7 +42,7 @@ class CRAMSegmenter(AgentEpisodeSegmenter):
         Plan.add_on_start_callback(self.start_action_callback, action_type=action_type)
         Plan.add_on_end_callback(self.end_action_callback, action_type=action_type)
 
-    def start_action_callback(self, action_node: ResolvedActionNode):
+    def start_action_callback(self, action_node: ActionNode[ActionDescription]):
         """
         The action callback method that is called when an action is performed.
 
@@ -54,7 +54,7 @@ class CRAMSegmenter(AgentEpisodeSegmenter):
         # print(f"Action Started: {action_node}")
         self.start_action_queue.put(action_node)
 
-    def end_action_callback(self, action_node: ResolvedActionNode):
+    def end_action_callback(self, action_node: ActionNode[ActionDescription]):
         """
         The action callback method that is called when an action is performed.
 

--- a/src/segmind/utils.py
+++ b/src/segmind/utils.py
@@ -6,26 +6,29 @@ import time
 from abc import ABC, abstractmethod
 
 import numpy as np
+from pycram.designator import ObjectDesignatorDescription
+from semantic_digital_twin.collision_checking.collision_detector import Collision
+from semantic_digital_twin.semantic_annotations.semantic_annotations import Floor
+from semantic_digital_twin.spatial_types import Vector3
+from semantic_digital_twin.world import World
+from semantic_digital_twin.world_description.geometry import BoundingBox
+from semantic_digital_twin.world_description.world_entity import Body
 from typing_extensions import List, Optional, Tuple
 
 from pycram.datastructures.dataclasses import Color
-from pycram.datastructures.dataclasses import (ContactPointsList, AxisAlignedBoundingBox as AABB, BoxVisualShape)
 from pycram.datastructures.enums import Arms, Grasp, AxisIdentifier
 from pycram.datastructures.grasp import GraspDescription
-from pycram.datastructures.pose import Transform, Vector3
-from pycram.datastructures.world import World, UseProspectionWorld
-from pycram.datastructures.world_entity import PhysicalBody
-from pycram.object_descriptors.generic import ObjectDescription as GenericObjectDescription
-from pycram.ros import logdebug, logwarn
+from pycram.datastructures.pose import Transform
+
+
 from pycram.tf_transformations import quaternion_inverse, quaternion_multiply
-from pycram.world_concepts.world_object import Object
-from pycrap.ontologies import Supporter, Floor
+
 
 try:
     from semantic_world.views import Container
 except ImportError:
     Container = None
-    logwarn("Container view is not available. Some functionalities may not work as expected.")
+    print("Container view is not available. Some functionalities may not work as expected.")
 
 from gtts import gTTS
 import pygame
@@ -65,11 +68,11 @@ def text_to_speech(text: str):
                 time.sleep(0.1)
                 continue
         except pygame.error:
-            logwarn("Audio not available, running in silent mode.")
+            print("Audio not available, running in silent mode.")
 
 
-def is_object_supported_by_container_body(obj: PhysicalBody, distance: float = 0.07,
-                                          bodies_to_check: Optional[List[PhysicalBody]] = None) -> bool:
+def is_object_supported_by_container_body(obj: Body, distance: float = 0.07,
+                                          bodies_to_check: Optional[List[Body]] = None) -> bool:
     if bodies_to_check is None:
         bodies_to_check = obj.contact_points.get_all_bodies()
     if hasattr(obj.world, "views") and obj.world.views is not None:
@@ -90,7 +93,7 @@ def is_object_supported_by_container_body(obj: PhysicalBody, distance: float = 0
             return False
 
 
-def get_arm_and_grasp_description_for_object(obj: Object) -> Tuple[Arms, GraspDescription]:
+def get_arm_and_grasp_description_for_object(obj: Body) -> Tuple[Arms, GraspDescription]:
     obj_pose = obj.pose
     left_arm_pose = World.current_world.robot.get_link_pose("l_gripper_tool_frame")
     right_arm_pose = World.current_world.robot.get_link_pose("r_gripper_tool_frame")
@@ -139,7 +142,7 @@ class PropagatingThread(threading.Thread, ABC):
         pass
 
 
-def check_if_object_is_supported(obj: Object, distance: Optional[float] = 0.03) -> bool:
+def check_if_object_is_supported(obj: Body, distance: Optional[float] = 0.03) -> bool:
     """
     Check if the object is supported by any other object.
 
@@ -158,7 +161,7 @@ def check_if_object_is_supported(obj: Object, distance: Optional[float] = 0.03) 
     return supported
 
 
-def check_if_object_is_supported_using_contact_points(obj: Object, contact_points: ContactPointsList) -> bool:
+def check_if_object_is_supported_using_contact_points(obj: Body, contact_points: Collision) -> bool:
     """
     Check if the object is supported by any other object using the contact points.
 
@@ -171,7 +174,7 @@ def check_if_object_is_supported_using_contact_points(obj: Object, contact_point
             return True
 
 
-def get_support(obj: Object, contact_bodies: Optional[List[PhysicalBody]] = None) -> Optional[PhysicalBody]:
+def get_support(obj: Body, contact_bodies: Optional[List[Body]] = None) -> Optional[Body]:
     """
     Check if the object is in contact with a supporting surface and returns it.
 
@@ -182,8 +185,8 @@ def get_support(obj: Object, contact_bodies: Optional[List[PhysicalBody]] = None
     if not contact_bodies:
         contact_bodies = obj.contact_points.get_all_bodies()
     excluded_bodies = [obj]
-    if isinstance(obj, Object):
-        excluded_bodies.extend(list(obj.links.values()))
+    if isinstance(obj, Body):
+        excluded_bodies.extend(list(obj.child_kinematic_structure_entities))
     for body in contact_bodies:
         if body in excluded_bodies:
             continue
@@ -201,13 +204,13 @@ def get_support(obj: Object, contact_bodies: Optional[List[PhysicalBody]] = None
         tracked_object_base = obj.position
         if tracked_object_base.z + 0.001 >= surface_z and intersection.width >= 0.5 * obj_bbox.width and \
                 intersection.depth >= 0.5 * obj_bbox.depth:
-            logdebug(f"Object {obj.name} IS supported by {body.name}")
+            print(f"Object {obj.name} IS supported by {body.name}")
             return body
-    logdebug(f"Object {obj.name} IS NOT supported")
+    print(f"Object {obj.name} IS NOT supported")
 
 
-def check_if_object_is_supported_by_another_object(obj: Object, support_obj: Object,
-                                                   contact_points: Optional[ContactPointsList] = None) -> bool:
+def check_if_object_is_supported_by_another_object(obj: Body, support_obj: Body,
+                                                   contact_points: Optional[Collision] = None) -> bool:
     """
     Check if the object is supported by another object.
 
@@ -241,11 +244,11 @@ class Imaginator:
     """
     A class that provides methods for imagining objects.
     """
-    surfaces_created: List[Object] = []
+    surfaces_created: List[Body] = []
     latest_surface_idx: int = 0
 
     @classmethod
-    def imagine_support_from_aabb(cls, aabb: AABB) -> Object:
+    def imagine_support_from_aabb(cls, aabb: BoundingBox) -> Body:
         """
         Imagine a support with the size of the axis-aligned bounding box.
 
@@ -255,7 +258,7 @@ class Imaginator:
         return cls._imagine_support(aabb=aabb)
 
     @classmethod
-    def imagine_support_for_object(cls, obj: Object, support_thickness: Optional[float] = 0.005) -> Object:
+    def imagine_support_for_object(cls, obj: Body, support_thickness: Optional[float] = 0.005) -> Body:
         """
         Imagine a support that supports the object and has a specified thickness.
 
@@ -266,9 +269,9 @@ class Imaginator:
         return cls._imagine_support(obj=obj, support_thickness=support_thickness)
 
     @classmethod
-    def _imagine_support(cls, obj: Optional[Object] = None,
-                         aabb: Optional[AABB] = None,
-                         support_thickness: Optional[float] = None) -> Object:
+    def _imagine_support(cls, obj: Optional[Body] = None,
+                         aabb: Optional[BoundingBox] = None,
+                         support_thickness: Optional[float] = None) -> Body:
         """
         Imagine a support for the object or with the size of the axis-aligned bounding box.
 
@@ -286,10 +289,10 @@ class Imaginator:
         print(f"support index: {cls.latest_surface_idx}")
         support_name = f"imagined_support_{cls.latest_surface_idx}"
         support_thickness = obj_aabb.depth if support_thickness is None else support_thickness
-        box_vis_shape = BoxVisualShape(Color(1, 1, 0, 1), Vector3(0, 0, 0),
+        box_vis_shape = BoundingBox(Color(1, 1, 0, 1), Vector3(0, 0, 0),
                                        Vector3(obj_aabb.width, obj_aabb.depth, support_thickness * 0.5))
-        support = GenericObjectDescription(support_name, box_vis_shape)
-        support_obj = Object(support_name, Supporter, None, support, color=support.color)
+        support = ObjectDesignatorDescription(list(support_name))
+        support_obj = Body(support_name, Supporter, None, support, color=support.color)
         support_position = obj_aabb.base_origin
         support_obj.set_position(support_position)
         cp = support_obj.closest_points(0.05)

--- a/src/segmind/utils.py
+++ b/src/segmind/utils.py
@@ -13,11 +13,10 @@ from semantic_digital_twin.reasoning.predicates import is_supported_by, contact
 from semantic_digital_twin.semantic_annotations.semantic_annotations import Floor
 from semantic_digital_twin.spatial_types import Vector3
 from semantic_digital_twin.world import World
-from semantic_digital_twin.world_description.geometry import BoundingBox
+from semantic_digital_twin.world_description.geometry import BoundingBox, Color
 from semantic_digital_twin.world_description.world_entity import Body
 from typing_extensions import List, Optional, Tuple
 
-from pycram.datastructures.dataclasses import Color
 from pycram.datastructures.enums import Arms, Grasp, AxisIdentifier
 from pycram.datastructures.grasp import GraspDescription
 from pycram.datastructures.pose import Transform

--- a/src/segmind/utils.py
+++ b/src/segmind/utils.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 from pycram.designator import ObjectDesignatorDescription
+from segmind import set_logger_level, LogLevel, logger
 from semantic_digital_twin.collision_checking.collision_detector import Collision
 from semantic_digital_twin.reasoning.predicates import is_supported_by, contact
 from semantic_digital_twin.semantic_annotations.semantic_annotations import Floor
@@ -24,7 +25,7 @@ from pycram.datastructures.pose import Transform
 
 from pycram.tf_transformations import quaternion_inverse, quaternion_multiply
 
-
+set_logger_level(LogLevel.DEBUG)
 try:
     from semantic_world.views import Container
 except ImportError:
@@ -186,6 +187,9 @@ def get_support(obj: Body, contact_bodies: Optional[List[Body]] = None) -> Optio
     :param contact_bodies: The bodies in contact with the object.
     :return: The supporting surface if it exists, None otherwise.
     """
+    print("Checking if object is in contact with supporting surface")
+    print(f"Object: {obj.name}")
+    print(f"Contacts: {contact_bodies}")
     if contact_bodies is None:
         contact_bodies = []
         for i in obj._world.bodies_with_enabled_collision:
@@ -199,39 +203,13 @@ def get_support(obj: Body, contact_bodies: Optional[List[Body]] = None) -> Optio
                 continue
             if contact(i, obj):
                 contact_bodies.append(i)
-
+    excluded_bodies = [obj]
     for cb in contact_bodies:
+        if cb in excluded_bodies:
+            continue
         if is_supported_by(obj, cb):
             return cb
-
-    return None
-    # if not contact_bodies:
-    #     contact_bodies = obj.contact_points.get_all_bodies()
-    # excluded_bodies = [obj]
-    # if isinstance(obj, Body):
-    #     excluded_bodies.extend(list(obj.child_kinematic_structure_entities))
-    # for body in contact_bodies:
-    #     if body in excluded_bodies:
-    #         continue
-    #     # if isinstance(body, Link):
-    #     #     parent_obj = body.parent_entity
-    #     # else:
-    #     #     parent_obj = body
-    #     # if issubclass(obj.obj_type, (Supporter, Location)):
-    #     if is_object_supported_by_container_body(obj, bodies_to_check=[body]):
-    #         return body
-    #     body_aabb = body.get_axis_aligned_bounding_box()
-    #     surface_z = body_aabb.max_z - 0.001
-    #     obj_bbox = obj.get_axis_aligned_bounding_box()
-    #     intersection = obj_bbox.intersection_with(body_aabb, axis_to_use=[AxisIdentifier.X, AxisIdentifier.Y])
-    #     tracked_object_base = obj.position
-    #     if tracked_object_base.z + 0.001 >= surface_z and intersection.width >= 0.5 * obj_bbox.width and \
-    #             intersection.depth >= 0.5 * obj_bbox.depth:
-    #         print(f"Object {obj.name} IS supported by {body.name}")
-    #         return body
-    # print(f"Object {obj.name} IS NOT supported")
-
-
+    logger.debug(f"No supporting surface found for object {obj.name}")
 def check_if_object_is_supported_by_another_object(obj: Body, support_obj: Body,
                                                    contact_points: Optional[list[Collision]] = None) -> bool:
     """
@@ -246,7 +224,7 @@ def check_if_object_is_supported_by_another_object(obj: Body, support_obj: Body,
         from .detectors.atomic_event_detectors import AbstractContactDetector
         all_contact_points, _ = AbstractContactDetector.get_contact_points_for_body(obj, 0.05, support_obj)
         contact_points = all_contact_points
-    
+
     normals = []
     for cp in contact_points:
         # Use the normal from the collision if available
@@ -259,7 +237,7 @@ def check_if_object_is_supported_by_another_object(obj: Body, support_obj: Body,
             if cp.body_a == obj:
                 normal = -normal
             normals.append(normal)
-            
+
     if len(normals) > 0:
         average_normal = np.mean(normals, axis=0)
         return is_vector_opposite_to_gravity(average_normal)

--- a/src/segmind/utils.py
+++ b/src/segmind/utils.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 from pycram.designator import ObjectDesignatorDescription
 from semantic_digital_twin.collision_checking.collision_detector import Collision
+from semantic_digital_twin.reasoning.predicates import is_supported_by, contact
 from semantic_digital_twin.semantic_annotations.semantic_annotations import Floor
 from semantic_digital_twin.spatial_types import Vector3
 from semantic_digital_twin.world import World
@@ -155,13 +156,15 @@ def check_if_object_is_supported(obj: Body, distance: Optional[float] = 0.03) ->
         prospection_obj = World.current_world.get_prospection_object_for_object(obj)
         dt = math.sqrt(2 * distance / 9.81) + 0.01  # time to fall distance
         World.current_world.simulate(dt)
-        cp = prospection_obj.contact_points
-        if get_support(prospection_obj, cp.get_all_bodies()) is None:
+        # cp = prospection_obj.contact_points
+        from .detectors.atomic_event_detectors import AbstractContactDetector
+        contact_points, _ = AbstractContactDetector.get_contact_points_for_body(prospection_obj, 0.05)
+        if get_support(prospection_obj, AbstractContactDetector.get_bodies_in_contact(contact_points)) is None:
             return False
     return supported
 
 
-def check_if_object_is_supported_using_contact_points(obj: Body, contact_points: Collision) -> bool:
+def check_if_object_is_supported_using_contact_points(obj: Body, contact_points: list[Collision]) -> bool:
     """
     Check if the object is supported by any other object using the contact points.
 
@@ -169,8 +172,9 @@ def check_if_object_is_supported_using_contact_points(obj: Body, contact_points:
     :param contact_points: The contact points of the object.
     :return: True if the object is supported, False otherwise.
     """
-    for body in contact_points.get_bodies_in_contact():
-        if check_if_object_is_supported_by_another_object(obj, body, contact_points.get_points_of_body(body)):
+    from .detectors.atomic_event_detectors import AbstractContactDetector
+    for body in AbstractContactDetector.get_bodies_in_contact(contact_points):
+        if check_if_object_is_supported_by_another_object(obj, body, AbstractContactDetector.get_points_of_body(contact_points, body)):
             return True
 
 
@@ -182,35 +186,54 @@ def get_support(obj: Body, contact_bodies: Optional[List[Body]] = None) -> Optio
     :param contact_bodies: The bodies in contact with the object.
     :return: The supporting surface if it exists, None otherwise.
     """
-    if not contact_bodies:
-        contact_bodies = obj.contact_points.get_all_bodies()
-    excluded_bodies = [obj]
-    if isinstance(obj, Body):
-        excluded_bodies.extend(list(obj.child_kinematic_structure_entities))
-    for body in contact_bodies:
-        if body in excluded_bodies:
-            continue
-        # if isinstance(body, Link):
-        #     parent_obj = body.parent_entity
-        # else:
-        #     parent_obj = body
-        # if issubclass(obj.obj_type, (Supporter, Location)):
-        if is_object_supported_by_container_body(obj, bodies_to_check=[body]):
-            return body
-        body_aabb = body.get_axis_aligned_bounding_box()
-        surface_z = body_aabb.max_z - 0.001
-        obj_bbox = obj.get_axis_aligned_bounding_box()
-        intersection = obj_bbox.intersection_with(body_aabb, axis_to_use=[AxisIdentifier.X, AxisIdentifier.Y])
-        tracked_object_base = obj.position
-        if tracked_object_base.z + 0.001 >= surface_z and intersection.width >= 0.5 * obj_bbox.width and \
-                intersection.depth >= 0.5 * obj_bbox.depth:
-            print(f"Object {obj.name} IS supported by {body.name}")
-            return body
-    print(f"Object {obj.name} IS NOT supported")
+    if contact_bodies is None:
+        contact_bodies = []
+        for i in obj._world.bodies_with_enabled_collision:
+            if not obj.has_collision():
+                continue
+            if obj.name.name == "root":
+                continue
+            if obj.name.name == "iCub":
+                continue
+            if i == obj:
+                continue
+            if contact(i, obj):
+                contact_bodies.append(i)
+
+    for cb in contact_bodies:
+        if is_supported_by(obj, cb):
+            return cb
+
+    return None
+    # if not contact_bodies:
+    #     contact_bodies = obj.contact_points.get_all_bodies()
+    # excluded_bodies = [obj]
+    # if isinstance(obj, Body):
+    #     excluded_bodies.extend(list(obj.child_kinematic_structure_entities))
+    # for body in contact_bodies:
+    #     if body in excluded_bodies:
+    #         continue
+    #     # if isinstance(body, Link):
+    #     #     parent_obj = body.parent_entity
+    #     # else:
+    #     #     parent_obj = body
+    #     # if issubclass(obj.obj_type, (Supporter, Location)):
+    #     if is_object_supported_by_container_body(obj, bodies_to_check=[body]):
+    #         return body
+    #     body_aabb = body.get_axis_aligned_bounding_box()
+    #     surface_z = body_aabb.max_z - 0.001
+    #     obj_bbox = obj.get_axis_aligned_bounding_box()
+    #     intersection = obj_bbox.intersection_with(body_aabb, axis_to_use=[AxisIdentifier.X, AxisIdentifier.Y])
+    #     tracked_object_base = obj.position
+    #     if tracked_object_base.z + 0.001 >= surface_z and intersection.width >= 0.5 * obj_bbox.width and \
+    #             intersection.depth >= 0.5 * obj_bbox.depth:
+    #         print(f"Object {obj.name} IS supported by {body.name}")
+    #         return body
+    # print(f"Object {obj.name} IS NOT supported")
 
 
 def check_if_object_is_supported_by_another_object(obj: Body, support_obj: Body,
-                                                   contact_points: Optional[Collision] = None) -> bool:
+                                                   contact_points: Optional[list[Collision]] = None) -> bool:
     """
     Check if the object is supported by another object.
 
@@ -220,8 +243,23 @@ def check_if_object_is_supported_by_another_object(obj: Body, support_obj: Body,
     :return: True if the object is supported by the support object, False otherwise.
     """
     if contact_points is None:
-        contact_points = obj.get_contact_points_with_body(support_obj)
-    normals = [cp.normal.to_list() for cp in contact_points if any(cp.normal.to_list())]
+        from .detectors.atomic_event_detectors import AbstractContactDetector
+        all_contact_points, _ = AbstractContactDetector.get_contact_points_for_body(obj, 0.05, support_obj)
+        contact_points = all_contact_points
+    
+    normals = []
+    for cp in contact_points:
+        # Use the normal from the collision if available
+        # In TrimeshCollisionDetector, map_V_n_input is a-b
+        if cp.map_V_n_input is not None and any(cp.map_V_n_input):
+            # If body_a is obj, the normal points from obj to support_obj.
+            # For support, we want the normal pointing UP (against gravity).
+            # If body_a is support_obj, then map_V_n_input points support -> obj, which is what we want.
+            normal = cp.map_V_n_input
+            if cp.body_a == obj:
+                normal = -normal
+            normals.append(normal)
+            
     if len(normals) > 0:
         average_normal = np.mean(normals, axis=0)
         return is_vector_opposite_to_gravity(average_normal)
@@ -295,8 +333,11 @@ class Imaginator:
         support_obj = Body(support_name, Supporter, None, support, color=support.color)
         support_position = obj_aabb.base_origin
         support_obj.set_position(support_position)
-        cp = support_obj.closest_points(0.05)
-        contacted_objects = cp.get_objects_that_have_points()
+        # cp = support_obj.closest_points(0.05)
+        # contacted_objects = cp.get_objects_that_have_points()
+        from .detectors.atomic_event_detectors import AbstractContactDetector
+        contact_points, _ = AbstractContactDetector.get_contact_points_for_body(support_obj, 0.05)
+        contacted_objects = AbstractContactDetector.get_bodies_in_contact(contact_points)
         contacted_surfaces = [obj for obj in contacted_objects if obj in cls.surfaces_created and obj != support_obj]
         for obj in contacted_surfaces:
             support_obj = support_obj.merge(obj)

--- a/test/test_contact_events.py
+++ b/test/test_contact_events.py
@@ -1,0 +1,141 @@
+import time
+
+import rclpy
+from narwhals import Object
+
+from Segmind.test import test_worlds
+from Segmind.test.test_worlds import setup_contact_world
+from segmind import set_logger_level, LogLevel, logger
+from segmind.datastructures.events import CloseContactEvent, ContactEvent, LossOfCloseContactEvent, LossOfContactEvent
+from segmind.datastructures.object_tracker import ObjectTrackerFactory
+from segmind.detectors.atomic_event_detectors import ContactDetector, LossOfContactDetector
+from segmind.event_logger import EventLogger
+from semantic_digital_twin.adapters.ros.visualization.viz_marker import VizMarkerPublisher
+from semantic_digital_twin.spatial_types import HomogeneousTransformationMatrix
+from semantic_digital_twin.world import World
+from semantic_digital_twin.world_description.connections import FixedConnection
+from semantic_digital_twin.world_description.world_entity import Body
+
+set_logger_level(LogLevel.DEBUG)
+
+class TestContactEvent:
+    world: World
+    viz_marker_publisher: VizMarkerPublisher
+
+    def test_contact_events(self):
+        self.world = setup_contact_world()
+        self.visualize(self.world)
+        self.tracked_obj = self.world.get_body_by_name("cylinder_body")
+        obj_tracker = ObjectTrackerFactory.get_tracker(self.tracked_obj)
+        contact_detector = self.run_and_get_contact_detector(self.tracked_obj)
+        loss_contact_detector = self.run_and_get_loss_contact_detector(self.tracked_obj)
+
+        try:
+            contact_detector.detect_events()
+            loss_contact_detector.detect_events()
+
+            assert (len(contact_detector.latest_contact_bodies)) == 0
+            assert (len(contact_detector.latest_close_bodies)) == 0
+            assert (len(obj_tracker.get_event_history())) == 0
+
+            with self.world.modify_world():
+                root_C_cylinder = HomogeneousTransformationMatrix.from_xyz_rpy(
+                    x=self.tracked_obj.global_pose.x ,y=-3.05, z=self.tracked_obj.global_pose.z
+                )
+                with self.world.modify_world():
+                    cylinder_conn = FixedConnection(
+                        parent=self.world.root,
+                        child=self.tracked_obj,
+                        parent_T_connection_expression=root_C_cylinder
+                    )
+                    self.world.add_connection(cylinder_conn)
+
+            time.sleep(1)
+            loss_contact_detector.detect_events()
+            contact_detector.detect_events()
+
+            assert (len(contact_detector.latest_close_bodies)) == 2
+            assert (len(contact_detector.latest_contact_bodies)) == 0
+
+            assert (len(obj_tracker.get_event_history())) == 2
+            assert type(obj_tracker.get_latest_event()) == CloseContactEvent
+
+            with self.world.modify_world():
+                root_C_cylinder = HomogeneousTransformationMatrix.from_xyz_rpy(
+                    x=self.tracked_obj.global_pose.x, y=-3.2, z=self.tracked_obj.global_pose.z
+                )
+                with self.world.modify_world():
+                    cylinder_conn = FixedConnection(
+                        parent=self.world.root,
+                        child=self.tracked_obj,
+                        parent_T_connection_expression=root_C_cylinder
+                    )
+                    self.world.add_connection(cylinder_conn)
+
+            time.sleep(1)
+            loss_contact_detector.detect_events()
+            contact_detector.detect_events()
+
+            assert (len(contact_detector.latest_contact_bodies)) == 2
+            assert (len(contact_detector.latest_close_bodies)) == 0
+
+            # Some remarks here: Since both events are happening at the same Time, both events can be as last events.
+            assert (len(obj_tracker.get_event_history())) == 6
+            assert type(obj_tracker.get_latest_event()) == LossOfCloseContactEvent or ContactEvent
+            assert obj_tracker.get_latest_event_of_type(ContactEvent) is not None
+            assert obj_tracker.get_latest_event_of_type(LossOfCloseContactEvent) is not None
+
+            with self.world.modify_world():
+                root_C_cylinder = HomogeneousTransformationMatrix.from_xyz_rpy(
+                    x=self.tracked_obj.global_pose.x, y=-2.2, z=self.tracked_obj.global_pose.z
+                )
+                with self.world.modify_world():
+                    cylinder_conn = FixedConnection(
+                        parent=self.world.root,
+                        child=self.tracked_obj,
+                        parent_T_connection_expression=root_C_cylinder
+                    )
+                    self.world.add_connection(cylinder_conn)
+
+            time.sleep(2)
+            loss_contact_detector.detect_events()
+            contact_detector.detect_events()
+
+            assert (len(contact_detector.latest_contact_bodies)) == 0
+            assert (len(contact_detector.latest_close_bodies)) == 0
+
+            assert (len(obj_tracker.get_event_history())) == 8
+            assert type(obj_tracker.get_latest_event()) == LossOfContactEvent
+
+
+        except Exception as e:
+            raise e
+
+        finally:
+            contact_detector.stop()
+            loss_contact_detector.stop()
+
+    @staticmethod
+    def run_and_get_contact_detector(obj: Body) -> ContactDetector:
+        logger = EventLogger()
+        contact_detector = ContactDetector(logger, obj)
+        contact_detector.start()
+        time.sleep(2)
+        return contact_detector
+
+    @staticmethod
+    def run_and_get_loss_contact_detector(obj: Body) -> LossOfContactDetector:
+        logger = EventLogger()
+        loss_contact_detector = LossOfContactDetector(logger, obj)
+        loss_contact_detector.start()
+        time.sleep(2)
+        return loss_contact_detector
+
+    def visualize(self, world):
+        logger.debug("Starting Visualization")
+        rclpy.init()
+        self.node = rclpy.create_node("test_node")
+        self.world = world
+        logger.debug("Node created")
+        self.viz_marker_publisher = VizMarkerPublisher(world=self.world, node=self.node)
+        self.viz_marker_publisher.with_tf_publisher()

--- a/test/test_cram_segmenter.py
+++ b/test/test_cram_segmenter.py
@@ -5,14 +5,18 @@ from os.path import dirname
 from typing import Optional
 
 from pycram.datastructures.grasp import GraspDescription
-from pycram.designators.action_designator import MoveTorsoActionDescription, PickUpActionDescription
 from pycram.language import SequentialPlan
-from pycram.datastructures.pose import PoseStamped, Vector3
-from pycram.ros import set_logger_level
+from pycram.datastructures.pose import PoseStamped
+from pycram.robot_plans import PickUpActionDescription, MoveTorsoActionDescription
+from rclpy.logging import set_logger_level
+from semantic_digital_twin.datastructures.definitions import TorsoState
+#from pycram.ros import set_logger_level
+from semantic_digital_twin.spatial_types import Vector3
+
 from segmind.segmenters.cram_segmenter import CRAMSegmenter
 from segmind.detectors.coarse_event_detectors import GeneralPickUpDetector
-from pycram.datastructures.enums import Arms, Grasp, TorsoState, WorldMode, LoggerLevel
-from pycram.datastructures.pose import Pose
+from pycram.datastructures.enums import Arms, Grasp, WorldMode, LoggerLevel
+#from pycram.datastructures.pose import Pose
 from pycram.datastructures.world import UseProspectionWorld
 from pycram.designator import ObjectDesignatorDescription
 from pycram.designators.action_designator import PickUpAction, MoveTorsoAction

--- a/test/test_cram_segmenter.py
+++ b/test/test_cram_segmenter.py
@@ -9,24 +9,21 @@ from pycram.language import SequentialPlan
 from pycram.datastructures.pose import PoseStamped
 from pycram.robot_plans import PickUpActionDescription, MoveTorsoActionDescription
 from rclpy.logging import set_logger_level
+from semantic_digital_twin.adapters.ros.visualization.viz_marker import VizMarkerPublisher
 from semantic_digital_twin.datastructures.definitions import TorsoState
 #from pycram.ros import set_logger_level
 from semantic_digital_twin.spatial_types import Vector3
+from semantic_digital_twin.world import World
+from semantic_digital_twin.world_description.world_entity import Agent, Body
 
 from segmind.segmenters.cram_segmenter import CRAMSegmenter
 from segmind.detectors.coarse_event_detectors import GeneralPickUpDetector
 from pycram.datastructures.enums import Arms, Grasp, WorldMode, LoggerLevel
 #from pycram.datastructures.pose import Pose
-from pycram.datastructures.world import UseProspectionWorld
 from pycram.designator import ObjectDesignatorDescription
-from pycram.designators.action_designator import PickUpAction, MoveTorsoAction
 from pycram.process_module import simulated_robot, ProcessModule
-from pycram.ros_utils.viz_marker_publisher import VizMarkerPublisher
 from pycram.plan import Plan
-from pycram.world_concepts.world_object import Object
-from pycram.worlds.bullet_world import BulletWorld
-from pycrap.ontologies import Robot, Milk, Kitchen
-from pycram.robot_description import RobotDescriptionManager
+
 try:
     from pyqt6.QtWidgets import QApplication
     from ripple_down_rules.user_interface.gui import RDRCaseViewer
@@ -37,27 +34,27 @@ except ImportError as e:
 
 class TestCRAMPlayer(unittest.TestCase):
     cram_segmenter: CRAMSegmenter
-    robot: Object
-    milk: Object
-    kitchen: Object
+    robot: Agent
+    milk: Body
+    kitchen: Body
     render_mode: WorldMode = WorldMode.DIRECT
     viz_marker_publisher: VizMarkerPublisher
-    world: BulletWorld
+    world: World
     app: Optional[QApplication] = None
     viewer: Optional[RDRCaseViewer] = None
     use_gui: bool = False
 
     @classmethod
     def setUpClass(cls):
-        RobotDescriptionManager().load_description("pr2")
-        cls.world = BulletWorld(mode=cls.render_mode)
+        #RobotDescriptionManager().load_description("pr2")
+        cls.world = World()
         set_logger_level(LoggerLevel.DEBUG)
-        cls.viz_marker_publisher = VizMarkerPublisher()
+        cls.viz_marker_publisher = VizMarkerPublisher(world=cls.world)
         cls.cram_segmenter = CRAMSegmenter(cls.world, [GeneralPickUpDetector], plot_timeline=True,
                                            plot_save_path=f"{dirname(__file__)}/test_results/cram_segmenter_test")
-        cls.kitchen = Object("kitchen", Kitchen, "kitchen.urdf")
-        cls.robot = Object("pr2", Robot, "pr2.urdf", pose=PoseStamped(Pose(Vector3(0.6, 0.4, 0))))
-        cls.milk = Object("milk", Milk, "milk.stl", pose=PoseStamped(Pose(Vector3(1.3, 1, 0.9))))
+        cls.kitchen = Body("kitchen", Kitchen, "kitchen.urdf")
+        cls.robot = Body("pr2", Robot, "pr2.urdf", pose=PoseStamped(Pose(Vector3(0.6, 0.4, 0))))
+        cls.milk = Body("milk", Milk, "milk.stl", pose=PoseStamped(Pose(Vector3(1.3, 1, 0.9))))
         if cls.use_gui and QApplication is not None:
             cls.app = QApplication(sys.argv)
             cls.viewer = RDRCaseViewer()
@@ -68,8 +65,7 @@ class TestCRAMPlayer(unittest.TestCase):
             Plan.current_plan.clear()
         time.sleep(0.05)
         self.world.reset_world(remove_saved_states=True)
-        with UseProspectionWorld():
-            pass
+
 
     @classmethod
     def tearDownClass(cls):

--- a/test/test_csv_episode_segmenter.py
+++ b/test/test_csv_episode_segmenter.py
@@ -8,14 +8,9 @@ from unittest import TestCase
 
 import pycram.ros
 from pycram.datastructures.enums import WorldMode
-from pycram.datastructures.pose import PoseStamped, Pose, Vector3
-from pycram.datastructures.world import World
-from pycram.robot_description import RobotDescriptionManager
-from pycram.ros import logdebug
-from pycram.ros_utils.viz_marker_publisher import VizMarkerPublisher
-from pycram.world_concepts.world_object import Object
-from pycram.worlds.bullet_world import BulletWorld
-from pycrap.ontologies import Location, Robot, PhysicalObject
+from pycram.datastructures.pose import PoseStamped
+from semantic_digital_twin.adapters.ros.visualization.viz_marker import VizMarkerPublisher
+from semantic_digital_twin.world import World
 from sqlalchemy import create_engine
 from sqlalchemy.orm.session import Session
 

--- a/test/test_csv_episode_segmenter.py
+++ b/test/test_csv_episode_segmenter.py
@@ -6,10 +6,18 @@ from os.path import dirname
 from pathlib import Path
 from unittest import TestCase
 
+import rclpy
+
 import pycram.ros
+from cognitive_robot_abstract_machine.test.krrood_test.dataset.semantic_world_like_classes import FixedConnection
 from pycram.datastructures.enums import WorldMode
 from pycram.datastructures.pose import PoseStamped
+from pycram.testing import SemanticWorldTestCase, setup_world
 from semantic_digital_twin.adapters.ros.visualization.viz_marker import VizMarkerPublisher
+from semantic_digital_twin.adapters.urdf import URDFParser
+from semantic_digital_twin.orm.model import HomogeneousTransformationMatrixMapping
+from semantic_digital_twin.spatial_types import Vector3
+from semantic_digital_twin.spatial_types.spatial_types import Pose, HomogeneousTransformationMatrix
 from semantic_digital_twin.world import World
 from sqlalchemy import create_engine
 from sqlalchemy.orm.session import Session
@@ -19,6 +27,8 @@ from segmind.detectors.coarse_event_detectors import GeneralPickUpDetector, Plac
 from segmind.detectors.spatial_relation_detector import InsertionDetector, SupportDetector, ContainmentDetector
 from segmind.episode_segmenter import NoAgentEpisodeSegmenter
 from segmind.players.csv_player import CSVEpisodePlayer
+from semantic_digital_twin.world_description.world_entity import Agent, Region, Body, Connection
+
 # from segmind.orm.ormatic_interface import *
 try:
     from pycram.worlds.multiverse2 import Multiverse
@@ -39,14 +49,12 @@ class TestMultiverseEpisodeSegmenter(TestCase):
         episode_dir = os.path.join(multiverse_episodes_dir, selected_episode)
         csv_file = os.path.join(episode_dir, f"data.csv")
         models_dir = os.path.join(episode_dir, "models")
-        scene_file_path = os.path.join(models_dir, f"scene.xml")
-        rdm = RobotDescriptionManager()
-        rdm.load_description("iCub")
-        cls.world: BulletWorld = BulletWorld(WorldMode.DIRECT)
+        cls.world = setup_world()
 
         cls.spawn_objects(models_dir)
-        pycram.ros.set_logger_level(pycram.datastructures.enums.LoggerLevel.DEBUG)
-        cls.viz_marker_publisher = VizMarkerPublisher()
+        rclpy.init()
+        cls.node = rclpy.create_node("test_node")
+        cls.viz_marker_publisher = VizMarkerPublisher(world=cls.world, node=cls.node)
         cls.file_player = CSVEpisodePlayer(csv_file, world=cls.world,
                                            time_between_frames=datetime.timedelta(milliseconds=4),
                                            position_shift=Vector3(0, 0, -0.05))
@@ -63,22 +71,37 @@ class TestMultiverseEpisodeSegmenter(TestCase):
         directory = Path(models_dir)
         urdf_files = [f.name for f in directory.glob('*.urdf')]
         for file in urdf_files:
+            file_path = "/home/sorin/dev/workspace/Segmind/resources/multiverse_episodes/icub_montessori_no_hands/models/" + file
             obj_name = Path(file).stem
             pose = PoseStamped()
             if obj_name == "iCub":
                 file = "iCub.urdf"
-                obj_type = Robot
-                pose = PoseStamped(Pose(Vector3(-0.8, 0, 0.55)))
+                obj_type = Agent
+                pose = [-0.8, 0, 0.55]
+                #PoseStamped(Pose(Vector3(-0.8, 0, 0.55)))
             elif obj_name == "scene":
-                obj_type = Location
+                obj_type = Region
             else:
-                obj_type = PhysicalObject
+                obj_type = Body
             try:
-                obj = Object(obj_name, obj_type, path=file, pose=pose)
+                obj_world = URDFParser.from_file(file_path).parse()
+                new_obj_connection = HomogeneousTransformationMatrix.from_xyz_rpy(
+                x=pose[0], y=pose[1], z=pose[2]
+                )
+                with cls.world.modify_world():
+                    cls.world.merge_world(obj_world,
+                                          root_connection=Connection(
+                                              parent=cls.world.root,
+                                              child=obj_world.root,
+                                              parent_T_connection_expression=new_obj_connection
+                                          ))
+
+                    #obj = Object(obj_name, obj_type, path=file, pose=pose)
             except Exception as e:
-                import pdb;
-                pdb.set_trace()
-                print(e)
+                #import pdb
+                #pdb.set_trace()
+                print(f"Error: {e}"),
+                print(f"Could not spawn object {obj_name} from file {file}. Skipping.")
                 continue
 
     @classmethod
@@ -87,19 +110,19 @@ class TestMultiverseEpisodeSegmenter(TestCase):
         Copy the model files to the world data directory.
         """
         # Copy the entire folder and its contents
-        shutil.copytree(models_dir, cls.world.conf.cache_dir + "/objects", dirs_exist_ok=True)
+       # shutil.copytree(models_dir, cls.world.conf.cache_dir + "/objects", dirs_exist_ok=True)
 
     @classmethod
     def tearDownClass(cls):
         cls.viz_marker_publisher._stop_publishing()
-        logdebug("Viz marker publisher has been stopped, exiting the world...")
+        print("Viz marker publisher has been stopped, exiting the world...")
         # cls.world.exit()
-        logdebug("World has been exited.")
+        print("World has been exited.")
 
     def tearDown(self):
         self.episode_segmenter.reset()
         self.file_player.reset()
-        logdebug("File player and episode segmenter have been reset.")
+        print("File player and episode segmenter have been reset.")
 
     def test_containment_detector(self):
         """

--- a/test/test_csv_episode_segmenter.py
+++ b/test/test_csv_episode_segmenter.py
@@ -54,10 +54,10 @@ class TestMultiverseEpisodeSegmenter(TestCase):
         with cls.world.modify_world():
             cls.world.add_kinematic_structure_entity(root)
         cls.spawn_objects(models_dir)
-        rclpy.init()
-        cls.node = rclpy.create_node("test_node")
+        #rclpy.init()
+        #cls.node = rclpy.create_node("test_node")
         logger.debug("Node created")
-        cls.viz_marker_publisher = VizMarkerPublisher(world=cls.world, node=cls.node)
+        #cls.viz_marker_publisher = VizMarkerPublisher(world=cls.world, node=cls.node)
         logger.debug("Viz marker publisher created")
         cls.file_player = CSVEpisodePlayer(csv_file, world=cls.world,
                                            time_between_frames=datetime.timedelta(milliseconds=4),
@@ -72,7 +72,6 @@ class TestMultiverseEpisodeSegmenter(TestCase):
         logger.debug("Episode segmenter created")
     @classmethod
     def spawn_objects(cls, models_dir):
-
         logging.log(logging.DEBUG, f"Spawning objects from {models_dir}...")
         #cls.copy_model_files_to_world_data_dir(models_dir)
         directory = Path(models_dir)
@@ -113,12 +112,11 @@ class TestMultiverseEpisodeSegmenter(TestCase):
         Copy the model files to the world data directory.
         """
         # Copy the entire folder and its contents
-        #shutil.copytree(models_dir, cls.world.conf.cache_dir + "/objects", dirs_exist_ok=True)
+        shutil.copytree(models_dir, cls.world.conf.cache_dir + "/objects", dirs_exist_ok=True)
 
     @classmethod
     def tearDownClass(cls):
         logger.debug("Stopping the file player...")
-        cls.viz_marker_publisher.stop()
         logger.debug("Viz marker publisher has been stopped, exiting the world...")
         # cls.world.exit()
         logger.debug("World has been exited.")
@@ -132,18 +130,19 @@ class TestMultiverseEpisodeSegmenter(TestCase):
         """
         Test the ContainmentDetector by checking if the iCub is contained within the scene.
         """
+        logger.debug("Testing the ContainmentDetector...")
         self.episode_segmenter.reset()
         self.episode_segmenter.detectors_to_start = [PlacingDetector]
         self.episode_segmenter.initial_detectors = [ContainmentDetector, SupportDetector]
         self.episode_segmenter.start()
         self.assertTrue(any([isinstance(e, ContainmentEvent) for e in self.episode_segmenter.logger.get_events()]))
 
-    def test_csv_replay(cls):
+    def test_csv_replay(self):
         # engine = create_engine('sqlite:///:memory:')
         # session = Session(engine)
         # mapper_registry.metadata.create_all(engine)
         #
         logger.debug("Starting the episode segmenter...")
-        cls.episode_segmenter.start()
+        self.episode_segmenter.start()
         # session.add_all(self.episode_segmenter.logger.get_events())
         # session.commit()

--- a/test/test_csv_episode_segmenter.py
+++ b/test/test_csv_episode_segmenter.py
@@ -1,16 +1,13 @@
 import datetime
+import logging
 import os
 import shutil
 import threading
 from os.path import dirname
 from pathlib import Path
 from unittest import TestCase
-
+from segmind import logger, set_logger_level, LogLevel
 import rclpy
-
-import pycram.ros
-from pycram.datastructures.enums import WorldMode
-from pycram.datastructures.pose import PoseStamped
 from pycram.testing import SemanticWorldTestCase, setup_world
 from semantic_digital_twin.adapters.ros.visualization.viz_marker import VizMarkerPublisher
 from semantic_digital_twin.adapters.urdf import URDFParser
@@ -19,7 +16,7 @@ from semantic_digital_twin.orm.model import HomogeneousTransformationMatrixMappi
 from semantic_digital_twin.spatial_types import Vector3
 from semantic_digital_twin.spatial_types.spatial_types import Pose, HomogeneousTransformationMatrix
 from semantic_digital_twin.world import World
-from semantic_digital_twin.world_description.connections import FixedConnection
+from semantic_digital_twin.world_description.connections import FixedConnection, Connection6DoF
 from sqlalchemy import create_engine
 from sqlalchemy.orm.session import Session
 
@@ -36,6 +33,7 @@ try:
 except ImportError:
     Multiverse = None
 
+set_logger_level(LogLevel.DEBUG)
 
 class TestMultiverseEpisodeSegmenter(TestCase):
     world: World
@@ -45,6 +43,7 @@ class TestMultiverseEpisodeSegmenter(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        logger.debug("lets go")
         multiverse_episodes_dir = f"{dirname(__file__)}/../resources/multiverse_episodes"
         selected_episode = "icub_montessori_no_hands"
         episode_dir = os.path.join(multiverse_episodes_dir, selected_episode)
@@ -57,19 +56,24 @@ class TestMultiverseEpisodeSegmenter(TestCase):
         cls.spawn_objects(models_dir)
         rclpy.init()
         cls.node = rclpy.create_node("test_node")
+        logger.debug("Node created")
         cls.viz_marker_publisher = VizMarkerPublisher(world=cls.world, node=cls.node)
+        logger.debug("Viz marker publisher created")
         cls.file_player = CSVEpisodePlayer(csv_file, world=cls.world,
                                            time_between_frames=datetime.timedelta(milliseconds=4),
                                            position_shift=Vector3(0, 0, -0.05))
+        logger.debug("File player created")
         cls.episode_segmenter = NoAgentEpisodeSegmenter(cls.file_player, annotate_events=True,
                                                         plot_timeline=True,
                                                         plot_save_path=f'{dirname(__file__)}/test_results/{Path(dirname(csv_file)).stem}',
                                                         detectors_to_start=[GeneralPickUpDetector, PlacingDetector],
                                                         initial_detectors=[InsertionDetector, SupportDetector,
                                                                            ContainmentDetector])
-
+        logger.debug("Episode segmenter created")
     @classmethod
     def spawn_objects(cls, models_dir):
+
+        logging.log(logging.DEBUG, f"Spawning objects from {models_dir}...")
         #cls.copy_model_files_to_world_data_dir(models_dir)
         directory = Path(models_dir)
         urdf_files = [f.name for f in directory.glob('*.urdf')]
@@ -80,28 +84,27 @@ class TestMultiverseEpisodeSegmenter(TestCase):
             if obj_name == "iCub":
                 file = "iCub.urdf"
                 obj_type = Agent
-                pose = [-0.8, 0, 0]
+                pose = [-0.8, 0, 0.55]
 
             elif obj_name == "scene":
                 obj_type = Region
-                pose = [0, 0, -0.55]
+                pose = [0, 0, 0]
 
             else:
                 obj_type = Body
-                pose = [0, 0, 2]
+                pose = [0, 0, 0]
             try:
                 obj_world = URDFParser.from_file(file_path).parse()
                 with cls.world.modify_world():
-                    cls.world.merge_world(obj_world, root_connection=FixedConnection(parent=cls.world.root, child=obj_world.root,
-                                                                                     parent_T_connection_expression=HomogeneousTransformationMatrix.from_xyz_rpy(x=pose[0], y=pose[1], z=pose[2])))
-
-
+                    cls.world.merge_world(obj_world, root_connection=Connection6DoF.create_with_dofs(world=cls.world, parent=cls.world.root, child=obj_world.root,
+                                                                                     parent_T_connection_expression=HomogeneousTransformationMatrix.from_xyz_rpy(x=pose[0], y=pose[1], z=pose[2])
+                                                                                     ))
 
             except Exception as e:
                 #import pdb
                 #pdb.set_trace()
-                print(f"Error: {e}"),
-                print(f"Could not spawn object {obj_name} from file {file}. Skipping.")
+                logger.debug(f"Error: {e}"),
+                logger.debug(f"Could not spawn object {obj_name} from file {file}. Skipping.")
                 continue
 
     @classmethod
@@ -114,16 +117,16 @@ class TestMultiverseEpisodeSegmenter(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        print("Stopping the file player...")
+        logger.debug("Stopping the file player...")
         cls.viz_marker_publisher.stop()
-        print("Viz marker publisher has been stopped, exiting the world...")
+        logger.debug("Viz marker publisher has been stopped, exiting the world...")
         # cls.world.exit()
-        print("World has been exited.")
+        logger.debug("World has been exited.")
 
     def tearDown(self):
         self.episode_segmenter.reset()
         self.file_player.reset()
-        print("File player and episode segmenter have been reset.")
+        logger.debug("File player and episode segmenter have been reset.")
 
     def test_containment_detector(self):
         """
@@ -135,11 +138,12 @@ class TestMultiverseEpisodeSegmenter(TestCase):
         self.episode_segmenter.start()
         self.assertTrue(any([isinstance(e, ContainmentEvent) for e in self.episode_segmenter.logger.get_events()]))
 
-    def test_csv_replay(self):
+    def test_csv_replay(cls):
         # engine = create_engine('sqlite:///:memory:')
         # session = Session(engine)
         # mapper_registry.metadata.create_all(engine)
         #
-        self.episode_segmenter.start()
+        logger.debug("Starting the episode segmenter...")
+        cls.episode_segmenter.start()
         # session.add_all(self.episode_segmenter.logger.get_events())
         # session.commit()

--- a/test/test_csv_episode_segmenter.py
+++ b/test/test_csv_episode_segmenter.py
@@ -9,16 +9,17 @@ from unittest import TestCase
 import rclpy
 
 import pycram.ros
-from cognitive_robot_abstract_machine.test.krrood_test.dataset.semantic_world_like_classes import FixedConnection
 from pycram.datastructures.enums import WorldMode
 from pycram.datastructures.pose import PoseStamped
 from pycram.testing import SemanticWorldTestCase, setup_world
 from semantic_digital_twin.adapters.ros.visualization.viz_marker import VizMarkerPublisher
 from semantic_digital_twin.adapters.urdf import URDFParser
+from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
 from semantic_digital_twin.orm.model import HomogeneousTransformationMatrixMapping
 from semantic_digital_twin.spatial_types import Vector3
 from semantic_digital_twin.spatial_types.spatial_types import Pose, HomogeneousTransformationMatrix
 from semantic_digital_twin.world import World
+from semantic_digital_twin.world_description.connections import FixedConnection
 from sqlalchemy import create_engine
 from sqlalchemy.orm.session import Session
 
@@ -49,8 +50,10 @@ class TestMultiverseEpisodeSegmenter(TestCase):
         episode_dir = os.path.join(multiverse_episodes_dir, selected_episode)
         csv_file = os.path.join(episode_dir, f"data.csv")
         models_dir = os.path.join(episode_dir, "models")
-        cls.world = setup_world()
-
+        cls.world = World()
+        root = Body(name=PrefixedName(name="root", prefix="world"))
+        with cls.world.modify_world():
+            cls.world.add_kinematic_structure_entity(root)
         cls.spawn_objects(models_dir)
         rclpy.init()
         cls.node = rclpy.create_node("test_node")
@@ -67,36 +70,33 @@ class TestMultiverseEpisodeSegmenter(TestCase):
 
     @classmethod
     def spawn_objects(cls, models_dir):
-        cls.copy_model_files_to_world_data_dir(models_dir)
+        #cls.copy_model_files_to_world_data_dir(models_dir)
         directory = Path(models_dir)
         urdf_files = [f.name for f in directory.glob('*.urdf')]
         for file in urdf_files:
-            file_path = "/home/sorin/dev/workspace/Segmind/resources/multiverse_episodes/icub_montessori_no_hands/models/" + file
+
+            file_path = "/home/sorin/dev/Segmind/resources/multiverse_episodes/icub_montessori_no_hands/models/" + file
             obj_name = Path(file).stem
-            pose = PoseStamped()
             if obj_name == "iCub":
                 file = "iCub.urdf"
                 obj_type = Agent
-                pose = [-0.8, 0, 0.55]
-                #PoseStamped(Pose(Vector3(-0.8, 0, 0.55)))
+                pose = [-0.8, 0, 0]
+
             elif obj_name == "scene":
                 obj_type = Region
+                pose = [0, 0, -0.55]
+
             else:
                 obj_type = Body
+                pose = [0, 0, 2]
             try:
                 obj_world = URDFParser.from_file(file_path).parse()
-                new_obj_connection = HomogeneousTransformationMatrix.from_xyz_rpy(
-                x=pose[0], y=pose[1], z=pose[2]
-                )
                 with cls.world.modify_world():
-                    cls.world.merge_world(obj_world,
-                                          root_connection=Connection(
-                                              parent=cls.world.root,
-                                              child=obj_world.root,
-                                              parent_T_connection_expression=new_obj_connection
-                                          ))
+                    cls.world.merge_world(obj_world, root_connection=FixedConnection(parent=cls.world.root, child=obj_world.root,
+                                                                                     parent_T_connection_expression=HomogeneousTransformationMatrix.from_xyz_rpy(x=pose[0], y=pose[1], z=pose[2])))
 
-                    #obj = Object(obj_name, obj_type, path=file, pose=pose)
+
+
             except Exception as e:
                 #import pdb
                 #pdb.set_trace()
@@ -110,11 +110,12 @@ class TestMultiverseEpisodeSegmenter(TestCase):
         Copy the model files to the world data directory.
         """
         # Copy the entire folder and its contents
-       # shutil.copytree(models_dir, cls.world.conf.cache_dir + "/objects", dirs_exist_ok=True)
+        #shutil.copytree(models_dir, cls.world.conf.cache_dir + "/objects", dirs_exist_ok=True)
 
     @classmethod
     def tearDownClass(cls):
-        cls.viz_marker_publisher._stop_publishing()
+        print("Stopping the file player...")
+        cls.viz_marker_publisher.stop()
         print("Viz marker publisher has been stopped, exiting the world...")
         # cls.world.exit()
         print("World has been exited.")

--- a/test/test_event_detectors.py
+++ b/test/test_event_detectors.py
@@ -39,6 +39,7 @@ class TestEventDetectors():
 
         try:
             translation_detector.update_with_latest_motion_data()
+            time.sleep(2)
             self.fridge = self.world.get_body_by_name("cabinet1")
             root_T_milk_connection = HomogeneousTransformationMatrix.from_xyz_rpy(
                 x = self.fridge.global_pose.x, y=self.fridge.global_pose.y, z=self.fridge.global_pose.z
@@ -52,14 +53,10 @@ class TestEventDetectors():
                 self.world.add_connection(milk_conn)
 
             # update twice to detect two displacements between three poses, since window size is 2
-            time.sleep(5)
             translation_detector.update_with_latest_motion_data()
-            time.sleep(5)
             translation_detector.update_with_latest_motion_data()
-            time.sleep(5)
             # wait one timestep to detect that it is moving
             time.sleep(translation_detector.get_n_changes_wait_time(1))
-            time.sleep(5)
             translation_event = milk_tracker.get_latest_event_of_type(TranslationEvent)
             assert(translation_event is not None)
 
@@ -68,7 +65,6 @@ class TestEventDetectors():
 
             # wait one timestep to detect that it is not moving
             time.sleep(translation_detector.get_n_changes_wait_time(1))
-
             assert(milk_tracker.get_first_event_of_type_after_event(StopTranslationEvent, translation_event)
                             is not None)
         except Exception as e:

--- a/test/test_event_detectors.py
+++ b/test/test_event_detectors.py
@@ -4,16 +4,20 @@ from datetime import timedelta
 import numpy as np
 from pycram.testing import SemanticWorldTestCase, setup_world
 from semantic_digital_twin.collision_checking.trimesh_collision_detector import TrimeshCollisionDetector
+from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
 from semantic_digital_twin.reasoning.predicates import InsideOf
 from semantic_digital_twin.spatial_types import HomogeneousTransformationMatrix
+from semantic_digital_twin.world import World
 from semantic_digital_twin.world_description.connections import FixedConnection
+from semantic_digital_twin.world_description.geometry import Cylinder, Box, Scale
+from semantic_digital_twin.world_description.shape_collection import ShapeCollection
 from semantic_digital_twin.world_description.world_entity import Body
 from typing_extensions import List, Type
 
 from segmind.datastructures.events import TranslationEvent, StopMotionEvent, StopTranslationEvent, \
-    ContactEvent, Event, EventUnion
+    CloseContactEvent, Event, EventUnion
 from segmind.datastructures.object_tracker import ObjectTrackerFactory
-from segmind.detectors.atomic_event_detectors import TranslationDetector, AtomicEventDetector
+from segmind.detectors.atomic_event_detectors import TranslationDetector, AtomicEventDetector, ContactDetector
 from segmind.detectors.coarse_event_detectors import GeneralPickUpDetector
 from segmind.detectors.spatial_relation_detector import InsertionDetector
 from segmind.detectors.motion_detection_helpers import has_consistent_direction, is_displaced
@@ -27,10 +31,9 @@ class TestEventDetectors:
 
     def test_general_pick_up_start_condition_checker(self):
         self.world = setup_world()
-        tcd = TrimeshCollisionDetector(self.world)
         milk = self.world.get_body_by_name("milk.stl")
         robot = self.world.get_body_by_name("base_link")
-        event = ContactEvent(close_bodies=[milk, robot], of_object=robot)
+        event = CloseContactEvent(close_bodies=[milk, robot], of_object=robot)
         GeneralPickUpDetector.start_condition_checker(event)
 
     def test_translation_detector(self):

--- a/test/test_event_detectors.py
+++ b/test/test_event_detectors.py
@@ -30,7 +30,7 @@ class TestEventDetectors:
         tcd = TrimeshCollisionDetector(self.world)
         milk = self.world.get_body_by_name("milk.stl")
         robot = self.world.get_body_by_name("base_link")
-        event = ContactEvent(contact_bodies=[milk, robot], of_object=robot)
+        event = ContactEvent(close_bodies=[milk, robot], of_object=robot)
         GeneralPickUpDetector.start_condition_checker(event)
 
     def test_translation_detector(self):

--- a/test/test_event_detectors.py
+++ b/test/test_event_detectors.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import numpy as np
 from pycram.testing import SemanticWorldTestCase, setup_world
 from semantic_digital_twin.collision_checking.trimesh_collision_detector import TrimeshCollisionDetector
+from semantic_digital_twin.reasoning.predicates import InsideOf
 from semantic_digital_twin.spatial_types import HomogeneousTransformationMatrix
 from semantic_digital_twin.world_description.connections import FixedConnection
 from semantic_digital_twin.world_description.world_entity import Body
@@ -21,7 +22,8 @@ from segmind.event_logger import EventLogger
 
 
 
-class TestEventDetectors():
+class TestEventDetectors:
+
 
     def test_general_pick_up_start_condition_checker(self):
         self.world = setup_world()
@@ -33,21 +35,21 @@ class TestEventDetectors():
 
     def test_translation_detector(self):
         self.world = setup_world()
-        self.milk = self.world.get_body_by_name("milk.stl")
-        milk_tracker = ObjectTrackerFactory.get_tracker(self.milk)
-        translation_detector = self.run_and_get_translation_detector(self.milk)
+        milk = self.world.get_body_by_name("milk.stl")
+        milk_tracker = ObjectTrackerFactory.get_tracker(milk)
+        translation_detector = self.run_and_get_translation_detector(milk)
 
         try:
             translation_detector.update_with_latest_motion_data()
             time.sleep(2)
-            self.fridge = self.world.get_body_by_name("cabinet1")
+            fridge = self.world.get_body_by_name("cabinet1")
             root_T_milk_connection = HomogeneousTransformationMatrix.from_xyz_rpy(
-                x = self.fridge.global_pose.x, y=self.fridge.global_pose.y, z=self.fridge.global_pose.z
+                x = fridge.global_pose.x, y=fridge.global_pose.y, z=fridge.global_pose.z
             )
             with self.world.modify_world():
                 milk_conn = FixedConnection(
                     parent=self.world.root,
-                    child=self.milk,
+                    child=milk,
                     parent_T_connection_expression=root_T_milk_connection
                 )
                 self.world.add_connection(milk_conn)
@@ -74,23 +76,33 @@ class TestEventDetectors():
             translation_detector.join()
 
     def test_insertion_detector(self):
-        milk_tracker = ObjectTrackerFactory.get_tracker(self.milk)
+        self.world = setup_world()
+        milk = self.world.get_body_by_name("milk.stl")
+        fridge = self.world.get_body_by_name("cabinet1")
+        milk_tracker = ObjectTrackerFactory.get_tracker(milk)
         time_between_frames = timedelta(seconds=0.01)
-        translation_detector = self.run_and_get_translation_detector(self.milk, time_between_frames)
-
-        sr_detector = InsertionDetector(wait_time=time_between_frames)
+        translation_detector = self.run_and_get_translation_detector(milk, time_between_frames)
+        logger = EventLogger()
+        sr_detector = InsertionDetector(logger=logger, world=self.world)
         sr_detector.start()
 
         try:
-            self.assertFalse(self.kitchen.links["iai_fridge_main"].contains_body(self.milk))
-            fridge_position = self.kitchen.links["iai_fridge_main"].position.to_list()
-            
+            assert InsideOf(milk, fridge).compute_containment_ratio() == 0.0
+
             # Get initial translation data
             translation_detector.update_with_latest_motion_data()
-            
-            self.milk.set_position(fridge_position)
 
-            # update trhice, the first three updates will trigger the displacement threshold, while the last update will trigger the consistent zero gradient
+            root_T_milk_connection = HomogeneousTransformationMatrix.from_xyz_rpy(
+                x=fridge.global_pose.x, y=fridge.global_pose.y, z=fridge.global_pose.z
+            )
+            with self.world.modify_world():
+                milk_conn = FixedConnection(
+                    parent=self.world.root,
+                    child=milk,
+                    parent_T_connection_expression=root_T_milk_connection
+                )
+                self.world.add_connection(milk_conn)
+            # update trice, the first three updates will trigger the displacement threshold, while the last update will trigger the consistent zero gradient
             translation_detector.update_with_latest_motion_data()
             translation_detector.update_with_latest_motion_data()
             translation_detector.update_with_latest_motion_data()
@@ -98,8 +110,8 @@ class TestEventDetectors():
             # because milk goes to moving state then to stop state thus we need to wait for 2 changes
             time.sleep(translation_detector.get_n_changes_wait_time(2))
             
-            self.assertTrue(milk_tracker.get_latest_event_of_type(StopMotionEvent) is not None)
-            self.assertTrue(self.kitchen.links["iai_fridge_main"].contains_body(self.milk))
+            assert (milk_tracker.get_latest_event_of_type(StopMotionEvent) is not None)
+            assert InsideOf(milk, fridge).compute_containment_ratio() == 1.0
         except Exception as e:
             raise e
         finally:
@@ -124,24 +136,24 @@ class TestEventDetectors():
         for i in range(3):
             a = np.zeros((3, 3))
             a[:, i] = 1
-            self.assertTrue(has_consistent_direction(a.tolist()))
+            assert(has_consistent_direction(a.tolist()))
             a = np.zeros((3, 3))
             a[:, i] = -1
-            self.assertTrue(has_consistent_direction(a.tolist()))
+            assert(has_consistent_direction(a.tolist()))
             a = np.zeros((3, 3))
             a[:, i] = -1
             a[1, i] = 1
-            self.assertFalse(has_consistent_direction(a.tolist()))
+            assert(has_consistent_direction(a.tolist())) is False
 
     def test_displacement_motion_detection_method(self):
         for i in range(3):
             a = np.zeros((3, 3))
             a[:, i] = 1
-            self.assertTrue(is_displaced(a.tolist(), 1.5))
+            assert(is_displaced(a.tolist(), 1.5))
             a = np.zeros((3, 3))
             a[:, i] = -1
-            self.assertTrue(is_displaced(a.tolist(), 1.5))
+            assert(is_displaced(a.tolist(), 1.5))
             a = np.zeros((3, 3))
             a[:, i] = -1
             a[1, i] = 1
-            self.assertFalse(is_displaced(a.tolist(), 1.5))
+            assert(is_displaced(a.tolist(), 1.5)) == False

--- a/test/test_event_detectors.py
+++ b/test/test_event_detectors.py
@@ -30,7 +30,7 @@ class TestEventDetectors:
         tcd = TrimeshCollisionDetector(self.world)
         milk = self.world.get_body_by_name("milk.stl")
         robot = self.world.get_body_by_name("base_link")
-        event = ContactEvent(contact_points=tcd.check_collision_between_bodies(milk, robot), of_object=robot)
+        event = ContactEvent(contact_bodies=[milk, robot], of_object=robot)
         GeneralPickUpDetector.start_condition_checker(event)
 
     def test_translation_detector(self):

--- a/test/test_event_detectors.py
+++ b/test/test_event_detectors.py
@@ -2,6 +2,11 @@ import time
 from datetime import timedelta
 
 import numpy as np
+from pycram.testing import SemanticWorldTestCase, setup_world
+from semantic_digital_twin.collision_checking.trimesh_collision_detector import TrimeshCollisionDetector
+from semantic_digital_twin.spatial_types import HomogeneousTransformationMatrix
+from semantic_digital_twin.world_description.connections import FixedConnection
+from semantic_digital_twin.world_description.world_entity import Body
 from typing_extensions import List, Type
 
 from segmind.datastructures.events import TranslationEvent, StopMotionEvent, StopTranslationEvent, \
@@ -12,38 +17,51 @@ from segmind.detectors.coarse_event_detectors import GeneralPickUpDetector
 from segmind.detectors.spatial_relation_detector import InsertionDetector
 from segmind.detectors.motion_detection_helpers import has_consistent_direction, is_displaced
 from segmind.event_logger import EventLogger
-from pycram.testing import BulletWorldTestCase
-from pycram.datastructures.enums import LoggerLevel
-from pycram.ros import set_logger_level
-from pycram.world_concepts.world_object import Object
-
-# set_logger_level(LoggerLevel.DEBUG)
 
 
-class TestEventDetectors(BulletWorldTestCase):
+
+
+class TestEventDetectors():
 
     def test_general_pick_up_start_condition_checker(self):
-        event = ContactEvent(self.milk, self.robot, 0.1)
+        self.world = setup_world()
+        tcd = TrimeshCollisionDetector(self.world)
+        milk = self.world.get_body_by_name("milk.stl")
+        robot = self.world.get_body_by_name("base_link")
+        event = ContactEvent(contact_points=tcd.check_collision_between_bodies(milk, robot), of_object=robot)
         GeneralPickUpDetector.start_condition_checker(event)
 
     def test_translation_detector(self):
+        self.world = setup_world()
+        self.milk = self.world.get_body_by_name("milk.stl")
         milk_tracker = ObjectTrackerFactory.get_tracker(self.milk)
         translation_detector = self.run_and_get_translation_detector(self.milk)
 
         try:
             translation_detector.update_with_latest_motion_data()
-            fridge_position = self.kitchen.links["iai_fridge_main"].position.to_list()
-            self.milk.set_position(fridge_position)
+            self.fridge = self.world.get_body_by_name("cabinet1")
+            root_T_milk_connection = HomogeneousTransformationMatrix.from_xyz_rpy(
+                x = self.fridge.global_pose.x, y=self.fridge.global_pose.y, z=self.fridge.global_pose.z
+            )
+            with self.world.modify_world():
+                milk_conn = FixedConnection(
+                    parent=self.world.root,
+                    child=self.milk,
+                    parent_T_connection_expression=root_T_milk_connection
+                )
+                self.world.add_connection(milk_conn)
 
             # update twice to detect two displacements between three poses, since window size is 2
+            time.sleep(5)
             translation_detector.update_with_latest_motion_data()
+            time.sleep(5)
             translation_detector.update_with_latest_motion_data()
-
+            time.sleep(5)
             # wait one timestep to detect that it is moving
             time.sleep(translation_detector.get_n_changes_wait_time(1))
-
+            time.sleep(5)
             translation_event = milk_tracker.get_latest_event_of_type(TranslationEvent)
-            self.assertTrue(translation_event is not None)
+            assert(translation_event is not None)
 
             # update once to detect two consistent gradients of zero value between last three updates.
             translation_detector.update_with_latest_motion_data()
@@ -51,7 +69,7 @@ class TestEventDetectors(BulletWorldTestCase):
             # wait one timestep to detect that it is not moving
             time.sleep(translation_detector.get_n_changes_wait_time(1))
 
-            self.assertTrue(milk_tracker.get_first_event_of_type_after_event(StopTranslationEvent, translation_event)
+            assert(milk_tracker.get_first_event_of_type_after_event(StopTranslationEvent, translation_event)
                             is not None)
         except Exception as e:
             raise e
@@ -95,7 +113,7 @@ class TestEventDetectors(BulletWorldTestCase):
             sr_detector.join()
 
     @staticmethod
-    def run_and_get_translation_detector(obj: Object, time_between_frames: timedelta = timedelta(seconds=0.01))\
+    def run_and_get_translation_detector(obj: Body, time_between_frames: timedelta = timedelta(seconds=0.01))\
             -> TranslationDetector:
         logger = EventLogger()
         translation_detector = TranslationDetector(logger, obj,

--- a/test/test_fame_episode_segmenter.py
+++ b/test/test_fame_episode_segmenter.py
@@ -4,17 +4,18 @@ from unittest import TestCase
 from os.path import dirname
 
 import pycram.ros
-from pycram.datastructures.world import World
+
 from pycram.datastructures.enums import WorldMode
+from semantic_digital_twin.adapters.ros.visualization.viz_marker import VizMarkerPublisher
+from semantic_digital_twin.semantic_annotations.semantic_annotations import Bowl, Cup
+from semantic_digital_twin.world import World
+
 from segmind.players.json_player import JSONPlayer
 from segmind.episode_segmenter import NoAgentEpisodeSegmenter
 from segmind.players.json_player import JSONPlayer
 from segmind.detectors.coarse_event_detectors import GeneralPickUpDetector
 from pycram.datastructures.enums import WorldMode
-from pycram.datastructures.world import World
-from pycram.ros_utils.viz_marker_publisher import VizMarkerPublisher
-from pycram.worlds.bullet_world import BulletWorld
-from pycrap.ontologies import Container, Bowl, Cup
+
 
 Multiverse = None
 try:

--- a/test/test_fame_episode_segmenter.py
+++ b/test/test_fame_episode_segmenter.py
@@ -5,7 +5,6 @@ from os.path import dirname
 
 import pycram.ros
 
-from pycram.datastructures.enums import WorldMode
 from semantic_digital_twin.adapters.ros.visualization.viz_marker import VizMarkerPublisher
 from semantic_digital_twin.semantic_annotations.semantic_annotations import Bowl, Cup
 from semantic_digital_twin.world import World
@@ -14,7 +13,7 @@ from segmind.players.json_player import JSONPlayer
 from segmind.episode_segmenter import NoAgentEpisodeSegmenter
 from segmind.players.json_player import JSONPlayer
 from segmind.detectors.coarse_event_detectors import GeneralPickUpDetector
-from pycram.datastructures.enums import WorldMode
+
 
 
 Multiverse = None

--- a/test/test_icub_demo.py
+++ b/test/test_icub_demo.py
@@ -23,20 +23,14 @@ except ImportError:
 import pycram
 from pycram.datastructures.enums import WorldMode, Arms, Grasp
 from pycram.datastructures.grasp import GraspDescription
-from pycram.datastructures.pose import PoseStamped, Pose, Vector3, Quaternion
-from pycram.datastructures.world import World
+from pycram.datastructures.pose import PoseStamped,
 from pycram.designator import ObjectDesignatorDescription
-from pycram.designators.action_designator import PickUpActionDescription, ParkArmsActionDescription, PlaceAction, \
-    PlaceActionDescription
+
 from pycram.external_interfaces import giskard
 from pycram.failures import ObjectNotGraspedError
 from pycram.language import SequentialPlan
 from pycram.process_module import simulated_robot, real_robot
-from pycram.robot_description import RobotDescriptionManager
-from pycram.ros_utils.viz_marker_publisher import VizMarkerPublisher
-from pycram.world_concepts.world_object import Object
-from pycram.worlds.bullet_world import BulletWorld
-from pycrap.ontologies import Location, PhysicalObject, Robot
+
 
 
 @pytest.fixture(scope="module")

--- a/test/test_multiverse_episode_segmenter.py
+++ b/test/test_multiverse_episode_segmenter.py
@@ -9,20 +9,18 @@ import pytest
 
 
 import pycram.ros
-from pycram.datastructures.pose import PoseStamped, Pose, Vector3
-from pycram.datastructures.world import World
+from pycram.datastructures.pose import PoseStamped
+
 from pycram.datastructures.enums import WorldMode
-from pycram.robot_description import RobotDescriptionManager
-from pycram.world_concepts.world_object import Object
+from semantic_digital_twin.adapters.ros.visualization.viz_marker import VizMarkerPublisher
+from semantic_digital_twin.world import World
+
 from segmind.players.csv_player import CSVEpisodePlayer
 from segmind.episode_segmenter import NoAgentEpisodeSegmenter
 from segmind.detectors.coarse_event_detectors import GeneralPickUpDetector
 from segmind.detectors.spatial_relation_detector import InsertionDetector
 from pycram.datastructures.enums import WorldMode
-from pycram.datastructures.world import World
-from pycram.ros_utils.viz_marker_publisher import VizMarkerPublisher
-from pycram.worlds.bullet_world import BulletWorld
-from pycrap.ontologies import Container, Bowl, Cup, Location, PhysicalObject, Robot
+
 
 try:
     from segmind.players.multiverse_player import MultiversePlayer

--- a/test/test_multiverse_episode_segmenter.py
+++ b/test/test_multiverse_episode_segmenter.py
@@ -10,16 +10,12 @@ import pytest
 
 import pycram.ros
 from pycram.datastructures.pose import PoseStamped
-
-from pycram.datastructures.enums import WorldMode
 from semantic_digital_twin.adapters.ros.visualization.viz_marker import VizMarkerPublisher
 from semantic_digital_twin.world import World
-
 from segmind.players.csv_player import CSVEpisodePlayer
 from segmind.episode_segmenter import NoAgentEpisodeSegmenter
 from segmind.detectors.coarse_event_detectors import GeneralPickUpDetector
 from segmind.detectors.spatial_relation_detector import InsertionDetector
-from pycram.datastructures.enums import WorldMode
 
 
 try:

--- a/test/test_neem_segmenter.py
+++ b/test/test_neem_segmenter.py
@@ -14,8 +14,6 @@ except ImportError:
 from segmind.detectors.coarse_event_detectors import PlacingDetector, GeneralPickUpDetector
 from unittest import TestCase
 
-from pycram.datastructures.enums import WorldMode, LoggerLevel
-
 
 # @pytest.mark.skipif(PyCRAMNEEMInterface is None, reason="PyCRAMNEEMInterface not available")
 @pytest.mark.skip(reason="PyCRAMNEEMInterface needs to be updated")

--- a/test/test_neem_segmenter.py
+++ b/test/test_neem_segmenter.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from semantic_digital_twin.adapters.ros.visualization.viz_marker import VizMarkerPublisher
 
 try:
     # from neem_pycram_interface import PyCRAMNEEMInterface
@@ -14,10 +15,6 @@ from segmind.detectors.coarse_event_detectors import PlacingDetector, GeneralPic
 from unittest import TestCase
 
 from pycram.datastructures.enums import WorldMode, LoggerLevel
-from pycram.ros_utils.viz_marker_publisher import VizMarkerPublisher
-from pycram.datastructures.world import World
-from pycram.worlds.bullet_world import BulletWorld
-from pycram.ros import set_logger_level
 
 
 # @pytest.mark.skipif(PyCRAMNEEMInterface is None, reason="PyCRAMNEEMInterface not available")

--- a/test/test_orm.py
+++ b/test/test_orm.py
@@ -6,7 +6,7 @@ from os.path import dirname
 from typing import Optional
 
 from ormatic.ormatic import logger, ORMatic
-from ormatic.utils import recursive_subclasses, ORMaticExplicitMapping
+from ormatic.utils import recursive_subclasses
 from sqlacodegen.generators import TablesGenerator
 from sqlalchemy import create_engine
 from sqlalchemy.orm import registry, Session
@@ -35,7 +35,7 @@ class ChildNotMappedClass(ParentMappedClass):
 
 # create set of classes that should be mapped
 classes = set()
-classes |= set(recursive_subclasses(ORMaticExplicitMapping))
+classes |= set(recursive_subclasses(ORMatic))
 classes |= {ParentMappedClass, ChildMappedClass}
 
 


### PR DESCRIPTION
Refactored how contacts are detected.

- We distinguish between CloseContact and Contact, where CloseContact means that an object is inside a given distance_threshold, but not fully colliding.
- Added a new testcase to test ContactEvents
- A lot of the logic components how to detect Contacts was refactored, now it basically revolves arround the contact()-predicate.
- To reproduce the new test you have to checkout my cramfork/segmind. 

For the test case i created a very simple world containing 3 objects which are initially not colliding (they are also not close), in the test file im moving one obj arround to test if the CloseContactEvent, ContactEvent and LossOfContactEvent are triggered (succesfully). 

What is still missing:
1. I tested without the "with_object" parameter set, so the Detector checks for every body in the world.
2. I tested it only on one object.
3. I have not tested yet the AgentContact Detectors.

